### PR TITLE
fix: where clause generation

### DIFF
--- a/src/layers/data-layer.ts
+++ b/src/layers/data-layer.ts
@@ -77,7 +77,7 @@ export class DataLayer {
   /**
    * Build WHERE clause from a single condition
    */
-    private buildWhereClause(condition: WhereCondition): sql.WhereExpression {
+  private buildWhereClause(condition: WhereCondition): sql.WhereExpression {
     if (condition.type === 'numeric') {
       const column = condition.column;
       const value = condition.value;

--- a/src/layers/data-layer.ts
+++ b/src/layers/data-layer.ts
@@ -77,20 +77,20 @@ export class DataLayer {
   /**
    * Build WHERE clause from a single condition
    */
-  private buildWhereClause(condition: WhereCondition): string {
+    private buildWhereClause(condition: WhereCondition): sql.WhereExpression {
     if (condition.type === 'numeric') {
       const column = condition.column;
       const value = condition.value;
 
       switch (condition.operator) {
         case '>=':
-          return `${column} >= ${value}`;
+          return sql.gte(column, value);
         case '>':
-          return `${column} > ${value}`;
+          return sql.gt(column, value);
         case '<=':
-          return `${column} <= ${value}`;
+          return sql.lte(column, value);
         case '<':
-          return `${column} < ${value}`;
+          return sql.lt(column, value);
       }
     } else {
       // String filter
@@ -100,13 +100,13 @@ export class DataLayer {
 
       switch (condition.operator) {
         case 'equals':
-          return `${column} = '${escapedValue}'`;
+          return sql.eq(column, escapedValue);
         case 'contains':
-          return `${column} LIKE '%${escapedValue}%'`;
+          return sql.like(column, `%${escapedValue}%`);
         case 'startsWith':
-          return `${column} LIKE '${escapedValue}%'`;
+          return sql.like(column, `${escapedValue}%`);
         case 'endsWith':
-          return `${column} LIKE '%${escapedValue}'`;
+          return sql.like(column, `%${escapedValue}`);
       }
     }
   }


### PR DESCRIPTION
- 概要： Filter 機能を動かしていたら以下のような不正なSQLが出力されたので修正

```sql
SELECT * FROM parquet_data
WHERE x BETWEEN ... AND ...
  AND y BETWEEN ... AND ...
  AND favorite_count <= 2 IS NULL  -- ❌ 不正なSQL
ORDER BY hash(tid)
LIMIT 100000
```

- 問題発生箇所：src/layers/data-layer.ts buildWhereClause関数
- 問題：文字列を query.where() に渡すと、sql-bricks が正しく処理できず、IS NULL という不正なSQLが生成されていた
- 変更点：文字列を返すのではなく、sql-bricksオブジェクトを返すように変更
- 動作確認済み