### PR TITLE
feat: optional soft-edge fade on gpuWhereConditions

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,33 @@ await plot.update({
 | **更新速度** | SQLクエリ再実行が必要 | 即座に反映 |
 | **用途** | 複雑な条件、全文検索 | スライダーなどリアルタイム操作 |
 
+### soft-edge フェード（`fade`）
+
+`gpuWhereConditions` の各条件に `fade` を付けると、フィルタ範囲 `[min,max]` の端で
+ポイントの不透明度（alpha）を連続的にランプさせられます。範囲外のハードカットは
+そのままで、端から内側へ `width` 分だけフェードします。`colorSql` の再評価を伴わず
+GPU の uniform 更新のみで反映されるため、フィルタ範囲をスライドさせながら毎フレーム
+安価にフェードできます（例: 時間窓スライド時のノードのフェードイン/アウト）。
+
+```typescript
+await plot.update({
+  data: {
+    gpuWhereConditions: [
+      {
+        column: 'created_at',
+        min: t0,
+        max: t1,
+        fade: { width: dt, edges: 'both' }, // 窓の両端から dt 分フェード
+      },
+    ],
+  },
+});
+```
+
+* `width`: 端のランプ幅（`column` と同じ単位、`> 0`。`0` 以下でフェード無効）
+* `edges`: フェードする端（`'both'`（既定） / `'min'` / `'max'`）。`min`/`max` を省略した
+  無限端は自動的にフェード無効。
+
 ## 型定義
 
 主な型定義:
@@ -175,6 +202,10 @@ interface GpuWhereCondition {
   column: string;  // gpuFilterColumnsで指定したカラム名
   min?: number;    // 最小値（省略時: -Infinity）
   max?: number;    // 最大値（省略時: +Infinity）
+  fade?: {         // オプション: 範囲端の soft-edge フェード
+    width: number;                       // 端のランプ幅（> 0）
+    edges?: 'both' | 'min' | 'max';      // フェードする端（既定 'both'）
+  };
 }
 
 // ホバーアウトラインオプション

--- a/src/renderer/gpu-layer.ts
+++ b/src/renderer/gpu-layer.ts
@@ -606,10 +606,14 @@ export class GpuLayer {
     renderFloatView[35] = fadeWidth[3];
     this.context.device.queue.writeBuffer(this.renderUniformBuffer, 0, renderUniformData);
 
-    // フィルター済みポイント用ユニフォーム（grayedMode = 1.0、フェードは共通）
+    // フィルター済みポイント用ユニフォーム（grayedMode = 1.0）
     if (this.filteredRenderUniformBuffer) {
       const filteredRenderUniformData = renderUniformData.slice(0);
       new Float32Array(filteredRenderUniformData)[21] = 1.0; // grayedMode = 1.0
+      // grayed パスはフィルタ範囲 [min,max] の外側の点を描画するため、フェードを
+      // 適用すると computeFadeAlpha が 0 になり点が消えてしまう（gray 表示にならない）。
+      // fadeEdgeFlags を 0 にしてフェードを無効化し、常に gray で表示する。
+      new Uint32Array(filteredRenderUniformData)[22] = 0;
       this.context.device.queue.writeBuffer(
         this.filteredRenderUniformBuffer,
         0,

--- a/src/renderer/gpu-layer.ts
+++ b/src/renderer/gpu-layer.ts
@@ -82,8 +82,13 @@ export class GpuLayer {
   /** フィルター済みポイント用レンダリングユニフォームバッファ */
   private filteredRenderUniformBuffer: GPUBuffer | null = null;
 
-  /** GPUフィルター条件 */
-  private gpuFilterConditions: { columnIndex: number; min: number; max: number }[] = [];
+  /** GPUフィルター条件（range + optional soft-edge fade） */
+  private gpuFilterConditions: {
+    columnIndex: number;
+    min: number;
+    max: number;
+    fade?: { width: number; edges: 'both' | 'min' | 'max' };
+  }[] = [];
   /** WHERE条件フィルタが有効かどうか */
   private whereFilterEnabled: boolean = false;
 
@@ -278,7 +283,7 @@ export class GpuLayer {
     this.context.device.queue.writeBuffer(this.indexBuffer, 0, indices);
 
     this.renderUniformBuffer = this.context.device.createBuffer({
-      size: 96,
+      size: 144,
       usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
     });
 
@@ -304,7 +309,7 @@ export class GpuLayer {
     });
 
     this.filteredRenderUniformBuffer = this.context.device.createBuffer({
-      size: 96,
+      size: 144,
       usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
     });
 
@@ -389,6 +394,7 @@ export class GpuLayer {
         { binding: 0, resource: { buffer: this.renderUniformBuffer } },
         { binding: 1, resource: { buffer: this.allPointsBuffer } },
         { binding: 2, resource: { buffer: this.visibleIndicesBuffer } },
+        { binding: 3, resource: { buffer: this.filterColumnsBuffer } },
       ],
     });
 
@@ -398,6 +404,7 @@ export class GpuLayer {
         { binding: 0, resource: { buffer: this.filteredRenderUniformBuffer } },
         { binding: 1, resource: { buffer: this.allPointsBuffer } },
         { binding: 2, resource: { buffer: this.filteredIndicesBuffer } },
+        { binding: 3, resource: { buffer: this.filterColumnsBuffer } },
       ],
     });
   }
@@ -546,23 +553,63 @@ export class GpuLayer {
 
     const viewMatrix = this.createViewMatrix();
 
-    const renderUniformData = new Float32Array(24);
-    renderUniformData.set(viewMatrix, 0);
+    // GPUフィルタ条件から、フィルタ範囲（compute/render 共用）と
+    // per-column soft-edge フェード（render 専用）をまとめて構築する。
+    let activeFilterMask = 0;
+    const filterRangeMin = [-Infinity, -Infinity, -Infinity, -Infinity];
+    const filterRangeMax = [Infinity, Infinity, Infinity, Infinity];
+    const fadeWidth = [0, 0, 0, 0];
+    // 2bit/列: bit(2c)=min端をフェード, bit(2c+1)=max端をフェード
+    let fadeEdgeFlags = 0;
+    for (const condition of this.gpuFilterConditions) {
+      const c = condition.columnIndex;
+      if (c >= 0 && c < 4) {
+        activeFilterMask |= 1 << c;
+        filterRangeMin[c] = condition.min;
+        filterRangeMax[c] = condition.max;
+        if (condition.fade && condition.fade.width > 0) {
+          fadeWidth[c] = condition.fade.width;
+          const edges = condition.fade.edges;
+          if (edges !== 'max') fadeEdgeFlags |= 1 << (2 * c); // min端
+          if (edges !== 'min') fadeEdgeFlags |= 1 << (2 * c + 1); // max端
+        }
+      }
+    }
+
+    // 144バイト: f32 と u32 が混在するため ArrayBuffer に2つのビューを張る
+    const renderUniformData = new ArrayBuffer(144);
+    const renderFloatView = new Float32Array(renderUniformData);
+    const renderUint32View = new Uint32Array(renderUniformData);
+    renderFloatView.set(viewMatrix, 0);
     // Vertex Shaderで pow(zoom, 0.3) を計算するコストを避けるため、CPUで事前に計算して渡す
-    renderUniformData[16] = Math.pow(this.zoom, 0.3);
-    renderUniformData[17] = this.canvas.width;
-    renderUniformData[18] = this.canvas.height;
-    renderUniformData[19] = this.pointAlpha;
-    renderUniformData[20] = this.pointSizeScale;
+    renderFloatView[16] = Math.pow(this.zoom, 0.3);
+    renderFloatView[17] = this.canvas.width;
+    renderFloatView[18] = this.canvas.height;
+    renderFloatView[19] = this.pointAlpha;
+    renderFloatView[20] = this.pointSizeScale;
     // grayedMode: 0.0 (通常ポイント用)
-    renderUniformData[21] = 0.0;
+    renderFloatView[21] = 0.0;
+    // per-column soft-edge フェード（gpuWhereConditions.fade）
+    renderUint32View[22] = fadeEdgeFlags >>> 0;
+    // [23] = padding(u32)
+    renderFloatView[24] = filterRangeMin[0]; // filterRangeMin: vec4 @ byte 96
+    renderFloatView[25] = filterRangeMin[1];
+    renderFloatView[26] = filterRangeMin[2];
+    renderFloatView[27] = filterRangeMin[3];
+    renderFloatView[28] = filterRangeMax[0]; // filterRangeMax: vec4 @ byte 112
+    renderFloatView[29] = filterRangeMax[1];
+    renderFloatView[30] = filterRangeMax[2];
+    renderFloatView[31] = filterRangeMax[3];
+    renderFloatView[32] = fadeWidth[0]; // fadeWidth: vec4 @ byte 128
+    renderFloatView[33] = fadeWidth[1];
+    renderFloatView[34] = fadeWidth[2];
+    renderFloatView[35] = fadeWidth[3];
     this.context.device.queue.writeBuffer(this.renderUniformBuffer, 0, renderUniformData);
 
-    // フィルター済みポイント用ユニフォーム（grayedMode = 1.0）
+    // フィルター済みポイント用ユニフォーム（grayedMode = 1.0、フェードは共通）
     if (this.filteredRenderUniformBuffer) {
-      const filteredRenderUniformData = new Float32Array(24);
-      filteredRenderUniformData.set(renderUniformData);
-      filteredRenderUniformData[21] = 1.0; // grayedMode = 1.0
+      const filteredRenderUniformData = renderUniformData.slice(0);
+      new Float32Array(filteredRenderUniformData)[21] = 1.0; // grayedMode = 1.0
       this.context.device.queue.writeBuffer(
         this.filteredRenderUniformBuffer,
         0,
@@ -596,18 +643,7 @@ export class GpuLayer {
     computeUint32View[4] = this.calculateLodThreshold();
     computeUint32View[5] = this.totalPointCount;
 
-    let activeFilterMask = 0;
-    const filterRangeMin = [-Infinity, -Infinity, -Infinity, -Infinity];
-    const filterRangeMax = [Infinity, Infinity, Infinity, Infinity];
-
-    for (const condition of this.gpuFilterConditions) {
-      if (condition.columnIndex >= 0 && condition.columnIndex < 4) {
-        activeFilterMask |= 1 << condition.columnIndex;
-        filterRangeMin[condition.columnIndex] = condition.min;
-        filterRangeMax[condition.columnIndex] = condition.max;
-      }
-    }
-
+    // activeFilterMask / filterRangeMin / filterRangeMax は上で構築済み
     computeUint32View[6] = activeFilterMask;
     computeUint32View[7] = this.whereFilterEnabled ? 1 : 0;
 
@@ -848,7 +884,14 @@ export class GpuLayer {
    * GPUフィルター条件を設定する
    * @param conditions フィルター条件の配列
    */
-  setGpuFilterConditions(conditions: { columnIndex: number; min: number; max: number }[]): void {
+  setGpuFilterConditions(
+    conditions: {
+      columnIndex: number;
+      min: number;
+      max: number;
+      fade?: { width: number; edges: 'both' | 'min' | 'max' };
+    }[]
+  ): void {
     this.gpuFilterConditions = conditions;
     this.filterResultValid = false;
     this.updateUniforms();

--- a/src/renderer/shaders.ts
+++ b/src/renderer/shaders.ts
@@ -200,19 +200,63 @@ struct Uniforms {
   pointAlpha: f32,
   pointSizeScale: f32,
   grayedMode: f32,
-  _padding2: f32,
-  _padding3: f32,
+  // --- per-column soft-edge フェード（gpuWhereConditions.fade）---
+  // 2bit/列: bit(2c)=min端をフェード, bit(2c+1)=max端をフェード
+  fadeEdgeFlags: u32,
+  _fadePad: u32,
+  filterRangeMin: vec4<f32>,  // フィルタ下端（= フェード窓の下端）
+  filterRangeMax: vec4<f32>,  // フィルタ上端（= フェード窓の上端）
+  fadeWidth: vec4<f32>,       // 列ごとの端ランプ幅（0 = フェード無効）
 }
 
 struct VertexOutput {
   @builtin(position) position: vec4<f32>,
   @location(0) color: vec4<f32>,
   @location(1) pointCoord: vec2<f32>,
+  @location(2) fadeAlpha: f32,
 }
 
 @group(0) @binding(0) var<uniform> uniforms: Uniforms;
 @group(0) @binding(1) var<storage, read> allPoints: array<Point>;
 @group(0) @binding(2) var<storage, read> visibleIndices: array<u32>;
+@group(0) @binding(3) var<storage, read> filterColumns: array<vec4<f32>>;
+
+// 1列ぶんの soft-edge フェード係数。width<=0 で 1.0（無効）。
+// fadeMin/fadeMax はそれぞれ下端/上端でランプするか。無限端は clamp により自動で 1.0。
+fn fadeForColumn(t: f32, lo: f32, hi: f32, width: f32, fadeMin: bool, fadeMax: bool) -> f32 {
+  if (width <= 0.0) {
+    return 1.0;
+  }
+  var a: f32 = 1.0;
+  if (fadeMin) {
+    a = a * clamp((t - lo) / width, 0.0, 1.0);
+  }
+  if (fadeMax) {
+    a = a * clamp((hi - t) / width, 0.0, 1.0);
+  }
+  return a;
+}
+
+// gpuWhereConditions.fade に基づく per-point の alpha フェード係数。
+// 各列の値を filterColumns から読み、フィルタ範囲 [min,max] の端でランプする。
+// どの列もフェード無し（fadeEdgeFlags==0）なら filterColumns を読まず即 1.0。
+fn computeFadeAlpha(pointIdx: u32) -> f32 {
+  let flags = uniforms.fadeEdgeFlags;
+  if (flags == 0u) {
+    return 1.0;
+  }
+  let fc = filterColumns[pointIdx];
+  var a: f32 = 1.0;
+  a = a * fadeForColumn(fc.x, uniforms.filterRangeMin.x, uniforms.filterRangeMax.x,
+                        uniforms.fadeWidth.x, (flags & 1u) != 0u, (flags & 2u) != 0u);
+  a = a * fadeForColumn(fc.y, uniforms.filterRangeMin.y, uniforms.filterRangeMax.y,
+                        uniforms.fadeWidth.y, (flags & 4u) != 0u, (flags & 8u) != 0u);
+  a = a * fadeForColumn(fc.z, uniforms.filterRangeMin.z, uniforms.filterRangeMax.z,
+                        uniforms.fadeWidth.z, (flags & 16u) != 0u, (flags & 32u) != 0u);
+  a = a * fadeForColumn(fc.w, uniforms.filterRangeMin.w, uniforms.filterRangeMax.w,
+                        uniforms.fadeWidth.w, (flags & 64u) != 0u, (flags & 128u) != 0u);
+  return a;
+}
 
 fn unpackColor(argb: u32) -> vec4<f32> {
   let a = f32((argb >> 24u) & 0xFFu) / 255.0;
@@ -253,6 +297,7 @@ fn vertexMain(
   }
 
   output.pointCoord = (quadPosition + 1.0) * 0.5;
+  output.fadeAlpha = computeFadeAlpha(pointIdx);
 
   return output;
 }
@@ -268,6 +313,6 @@ fn fragmentMain(input: VertexOutput) -> @location(0) vec4<f32> {
 
   let alpha = smoothstep(0.25, 0.23, distSq);
 
-  return vec4<f32>(input.color.rgb, input.color.a * alpha * uniforms.pointAlpha);
+  return vec4<f32>(input.color.rgb, input.color.a * alpha * uniforms.pointAlpha * input.fadeAlpha);
 }
 `;

--- a/src/scatter-plot.ts
+++ b/src/scatter-plot.ts
@@ -476,16 +476,30 @@ export class ScatterPlot extends EventEmitter<ScatterPlotEventMap> {
    * @param conditions ユーザー指定のGPUフィルター条件
    * @returns GpuLayer用のフィルター条件配列
    */
-  private convertGpuWhereConditions(
-    conditions: GpuWhereCondition[]
-  ): { columnIndex: number; min: number; max: number }[] {
+  private convertGpuWhereConditions(conditions: GpuWhereCondition[]): {
+    columnIndex: number;
+    min: number;
+    max: number;
+    fade?: { width: number; edges: 'both' | 'min' | 'max' };
+  }[] {
     return conditions
       .filter((c) => this.gpuFilterColumnMapping.has(c.column))
-      .map((c) => ({
-        columnIndex: this.gpuFilterColumnMapping.get(c.column)!,
-        min: c.min ?? -Infinity,
-        max: c.max ?? Infinity,
-      }));
+      .map((c) => {
+        const converted: {
+          columnIndex: number;
+          min: number;
+          max: number;
+          fade?: { width: number; edges: 'both' | 'min' | 'max' };
+        } = {
+          columnIndex: this.gpuFilterColumnMapping.get(c.column)!,
+          min: c.min ?? -Infinity,
+          max: c.max ?? Infinity,
+        };
+        if (c.fade && c.fade.width > 0) {
+          converted.fade = { width: c.fade.width, edges: c.fade.edges ?? 'both' };
+        }
+        return converted;
+      });
   }
 
   /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -84,7 +84,7 @@ export interface RawSqlFilter {
 /** すべてのWHERE条件の共用体型 */
 export type WhereCondition = NumericFilter | StringFilter | RawSqlFilter;
 
-/** GPUフィルター条件 (range only) */
+/** GPUフィルター条件 (range + optional soft-edge fade) */
 export interface GpuWhereCondition {
   /** フィルター対象のカラム名 (gpuFilterColumnsで指定した名前) */
   column: string;
@@ -92,6 +92,20 @@ export interface GpuWhereCondition {
   min?: number;
   /** 最大値 (指定しない場合は +Infinity) */
   max?: number;
+  /**
+   * オプション: フィルタ範囲の端で alpha を連続的にランプする soft-edge フェード。
+   * 範囲 [min,max] のハードカットはそのまま、その端から内側へ width 分だけ
+   * フェードする。colorSql 再評価を伴わず GPU uniform 更新のみで毎フレーム安価
+   * に変化させられる（このフィルタ自体と同じコスト構造）。per-point 値は
+   * gpuFilterColumns 経由で既に GPU 常駐のため新規データアップロードは起きない。
+   * 無限端（min/max 省略側）は自動的にフェード無効。
+   */
+  fade?: {
+    /** 端のランプ幅（column と同じ単位, > 0）。0 以下でフェード無効 */
+    width: number;
+    /** どの端をフェードするか（既定 'both'） */
+    edges?: 'both' | 'min' | 'max';
+  };
 }
 
 /** フィルターされたポイントの表示モード */


### PR DESCRIPTION
Add `fade?: { width; edges? }` to GpuWhereCondition so a GPU range filter can ramp per-point alpha at its boundary instead of a hard cut. The filter range [min,max] doubles as the fade window: alpha ramps from 0 at the edge to 1 over `width` (same units as the column), inward. `edges` selects which side(s) fade ('both' default / 'min' / 'max'); open (omitted) bounds never fade.

Motivation: fading nodes while sliding a time window needs per-point alpha, which previously meant baking it into colorSql — a full DuckDB re-evaluation per frame (~250ms on a 25k-point map), unusable for animation. This path reuses the existing gpuFilterColumns GPU buffer and updates only render uniforms, so it costs the same as gpuWhereConditions (no DuckDB re-eval, no data re-upload) and animates smoothly.

- types: GpuWhereCondition.fade (re-exported via index).
- shaders: render Uniforms carries per-column fadeEdgeFlags + filterRangeMin/Max
  + fadeWidth (vec4); computeFadeAlpha multiplies clamp ramps per active column and is skipped entirely when no column fades. filterColumns bound to the render pipeline (binding 3).
- gpu-layer: build filter range + fade arrays once in updateUniforms; render uniform buffer 96->144 bytes; setGpuFilterConditions accepts fade.
- scatter-plot: convertGpuWhereConditions threads fade through (column->index).
- README: document fade under GPU filtering.

Because fade rides on gpuWhereConditions, it also applies at init via the existing initialGpuWhereConditions path.

Verified locally (Node 24): tsc + eslint clean (0 new warnings); unit checks of the uniform byte layout, ramp math, and edge-bit encoding; and a WebGPU render in Chrome showing the per-point alpha gradient.