### PR TITLE
fix: align GPU filter-column buffer to point order; harden gpuWhereCo…

### DIFF
--- a/src/data/data-layer.ts
+++ b/src/data/data-layer.ts
@@ -231,7 +231,11 @@ export class DataLayer {
         .join(', ');
 
       const data = await this.repository!.query({
-        toString: () => `SELECT ${columnSelects} FROM parquet_data`,
+        // ORDER BY rowid: GPU filter column buffer の行順を loadAllPoints/loadVisibilityFlags
+        //（いずれも ORDER BY rowid）と揃える。これが無いと per-point の filter 値が point
+        // buffer と別順序になり、GPU range フィルタや fade（filterColumns[pointIdx] 参照）が
+        // 誤った行の値を読む潜在バグになる。
+        toString: () => `SELECT ${columnSelects} FROM parquet_data ORDER BY rowid`,
       });
       if (!data || data.rowCount === 0) {
         return null;

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -12,6 +12,7 @@ const categoryMap: Record<ErrorCode, ErrorCategory> = {
   PARQUET_LOAD_FAILED: 'data',
   QUERY_FAILED: 'query',
   LABEL_FETCH_FAILED: 'label',
+  CONFIG_WARNING: 'data',
 };
 
 /**
@@ -26,6 +27,7 @@ const severityMap: Record<ErrorCode, ErrorSeverity> = {
   PARQUET_LOAD_FAILED: 'fatal',
   QUERY_FAILED: 'error',
   LABEL_FETCH_FAILED: 'warning',
+  CONFIG_WARNING: 'warning',
 };
 
 /**

--- a/src/scatter-plot.ts
+++ b/src/scatter-plot.ts
@@ -30,7 +30,10 @@ export class ScatterPlot extends EventEmitter<ScatterPlotEventMap> {
   private readonly dataSource: string | File | ArrayBuffer;
   private readonly labelSource?: string | File | ArrayBuffer;
   private readonly onDatabaseReady?: (conn: AsyncDuckDBConnection) => Promise<void>;
-  private readonly initialGpuWhereConditions?: GpuWhereCondition[];
+  /** 直近に指定された gpuWhereConditions（gpuFilterColumns 変更時に新 mapping で再解決するため保持） */
+  private currentGpuWhereConditions: GpuWhereCondition[] = [];
+  /** 直近に CONFIG_WARNING を出した「未登録 column 集合」のキー（hot path での重複 emit 抑制） */
+  private lastIgnoredGpuWhereColumnsKey = '';
   private readonly initialFilteredPointDisplayMode?: FilteredPointDisplayMode;
 
   /** GPUフィルターカラム名→インデックスのマッピング */
@@ -79,7 +82,7 @@ export class ScatterPlot extends EventEmitter<ScatterPlotEventMap> {
     this.dataSource = dataSource;
     this.labelSource = options.labels?.file ?? options.labels?.url;
     this.onDatabaseReady = options.onDatabaseReady;
-    this.initialGpuWhereConditions = options.data.gpuWhereConditions;
+    this.currentGpuWhereConditions = options.data.gpuWhereConditions ?? [];
     this.initialFilteredPointDisplayMode = options.data.filteredPointDisplayMode;
   }
 
@@ -97,8 +100,8 @@ export class ScatterPlot extends EventEmitter<ScatterPlotEventMap> {
         this.gpuFilterColumnMapping = gpuFilterData.columnMapping;
       }
 
-      if (this.initialGpuWhereConditions !== undefined) {
-        const conditions = this.convertGpuWhereConditions(this.initialGpuWhereConditions);
+      if (this.currentGpuWhereConditions.length > 0) {
+        const conditions = this.convertGpuWhereConditions(this.currentGpuWhereConditions);
         this.gpuLayer.setGpuFilterConditions(conditions);
         this.dataLayer.setGpuFilterRanges(conditions);
       }
@@ -306,6 +309,11 @@ export class ScatterPlot extends EventEmitter<ScatterPlotEventMap> {
    */
   async update(options: Partial<ScatterPlotOptions>): Promise<void> {
     if (options.data !== undefined) {
+      const gpuWhereConditionsChanged = options.data.gpuWhereConditions !== undefined;
+      if (gpuWhereConditionsChanged) {
+        this.currentGpuWhereConditions = options.data.gpuWhereConditions ?? [];
+      }
+
       const result = await this.dataLayer.updateOptions({
         sizeSql: options.data.sizeSql,
         colorSql: options.data.colorSql,
@@ -323,8 +331,10 @@ export class ScatterPlot extends EventEmitter<ScatterPlotEventMap> {
         }
       }
 
-      if (options.data.gpuWhereConditions !== undefined) {
-        const conditions = this.convertGpuWhereConditions(options.data.gpuWhereConditions);
+      // gpuFilterColumns が変わったときも、保持中の gpuWhereConditions を新しい mapping で
+      // 再解決する。古い columnIndex が残ったまま別カラムを誤フィルタするのを防ぐ。
+      if (result.gpuFilterColumnsChanged || gpuWhereConditionsChanged) {
+        const conditions = this.convertGpuWhereConditions(this.currentGpuWhereConditions);
         this.gpuLayer.setGpuFilterConditions(conditions);
         this.dataLayer.setGpuFilterRanges(conditions);
       }
@@ -482,6 +492,13 @@ export class ScatterPlot extends EventEmitter<ScatterPlotEventMap> {
     max: number;
     fade?: { width: number; edges: 'both' | 'min' | 'max' };
   }[] {
+    const ignoredColumns = Array.from(
+      new Set(
+        conditions.filter((c) => !this.gpuFilterColumnMapping.has(c.column)).map((c) => c.column)
+      )
+    );
+    this.warnIgnoredGpuWhereColumns(ignoredColumns);
+
     return conditions
       .filter((c) => this.gpuFilterColumnMapping.has(c.column))
       .map((c) => {
@@ -500,6 +517,35 @@ export class ScatterPlot extends EventEmitter<ScatterPlotEventMap> {
         }
         return converted;
       });
+  }
+
+  /**
+   * gpuFilterColumns に未登録の gpuWhereConditions.column を CONFIG_WARNING で通知する。
+   * 時間窓スライダ等が毎フレーム update() を呼ぶ hot path のため、未登録 column 集合が
+   * 前回と変わったときだけ emit する（同一警告の氾濫を防ぐ）。正常化したらキーをクリアし、
+   * 次に異常が起きたときに再度 emit できるようにする。
+   */
+  private warnIgnoredGpuWhereColumns(ignoredColumns: string[]): void {
+    const key = JSON.stringify(ignoredColumns.slice().sort());
+    if (key === this.lastIgnoredGpuWhereColumnsKey) {
+      return;
+    }
+    this.lastIgnoredGpuWhereColumnsKey = key;
+    if (ignoredColumns.length === 0) {
+      return;
+    }
+    this.emitError(
+      createError(
+        'CONFIG_WARNING',
+        'Some gpuWhereConditions were ignored because their columns are not registered in gpuFilterColumns.',
+        {
+          context: {
+            ignoredColumns,
+            availableGpuFilterColumns: [...this.gpuFilterColumnMapping.keys()],
+          },
+        }
+      )
+    );
   }
 
   /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -197,7 +197,8 @@ export type ErrorCode =
   | 'DATA_LAYER_NOT_INITIALIZED'
   | 'PARQUET_LOAD_FAILED'
   | 'QUERY_FAILED'
-  | 'LABEL_FETCH_FAILED';
+  | 'LABEL_FETCH_FAILED'
+  | 'CONFIG_WARNING';
 
 /** エラーイベントペイロード */
 export interface ScatterPlotError {


### PR DESCRIPTION
…nditions

Three related correctness fixes for the GPU fast path:

- loadGpuFilterColumns: add `ORDER BY rowid` so the per-point GPU filter-column buffer is ordered identically to the point buffer (loadAllPoints) and the visibility bitmap (loadVisibilityFlags), which already use `ORDER BY rowid`. Without it the GPU range filter and the soft-edge fade read filterColumns[pointIdx] against a mismatched row order whenever DuckDB returns the scan in non-rowid order — a latent bug affecting the shipped time-window filter and the 1.6.0 fade.

- Re-resolve gpuWhereConditions against the current column mapping whenever gpuFilterColumns changes. The latest conditions are retained and re-converted on either change, so a stale columnIndex can no longer filter the wrong column after a column-set change.

- Emit CONFIG_WARNING when a gpuWhereConditions column is not registered in gpuFilterColumns (previously dropped silently), de-duplicated by the ignored- column set so a per-frame hot path (e.g. a time-window slider) does not flood identical warnings; the key resets when the set becomes valid again.

Verified: tsc clean; eslint clean on changed files (only pre-existing no-explicit-any warnings remain).