### PR TITLE
perf: default to VoidLogger and stop per-mousemove hover DuckDB queries

### DIFF
--- a/src/data/data-layer.ts
+++ b/src/data/data-layer.ts
@@ -420,7 +420,13 @@ export class DataLayer {
    * @param thresholdPixels ヒットと見なす最大距離（ピクセル、デフォルト: 10）
    * @returns 見つかった場合はポイントデータ、そうでない場合はnull
    */
-  async findNearestPoint(
+  /**
+   * 画面座標に最も近いポイントの rowid を返す（spatial index のみ。DuckDB クエリは発行しない）。
+   * hover のたびに点データ（SELECT *）を取得するのを避け、rowid が前回と変わったときだけ
+   * findPointById を呼べるようにするための軽量版。
+   * @returns 見つかった場合は rowid、なければ null
+   */
+  findNearestPointId(
     screenX: number,
     screenY: number,
     canvasWidth: number,
@@ -430,7 +436,7 @@ export class DataLayer {
     panY: number,
     aspectRatio: number,
     thresholdPixels: number = 10
-  ): Promise<Record<string, any> | null> {
+  ): number | null {
     if (!this.spatialIndex.isBuilt()) {
       return null;
     }
@@ -445,15 +451,40 @@ export class DataLayer {
     const thresholdWorld = (thresholdClip * aspectRatio) / zoom;
     const thresholdWorldSq = thresholdWorld * thresholdWorld;
 
-    const nearestRowid = this.spatialIndex.findNearest(
-      worldX,
-      worldY,
-      thresholdWorldSq,
-      this.visibilityFlags,
-      this.filterColumnData,
-      this.gpuFilterRanges
+    return (
+      this.spatialIndex.findNearest(
+        worldX,
+        worldY,
+        thresholdWorldSq,
+        this.visibilityFlags,
+        this.filterColumnData,
+        this.gpuFilterRanges
+      ) ?? null
     );
+  }
 
+  async findNearestPoint(
+    screenX: number,
+    screenY: number,
+    canvasWidth: number,
+    canvasHeight: number,
+    zoom: number,
+    panX: number,
+    panY: number,
+    aspectRatio: number,
+    thresholdPixels: number = 10
+  ): Promise<Record<string, any> | null> {
+    const nearestRowid = this.findNearestPointId(
+      screenX,
+      screenY,
+      canvasWidth,
+      canvasHeight,
+      zoom,
+      panX,
+      panY,
+      aspectRatio,
+      thresholdPixels
+    );
     if (nearestRowid == null) {
       return null;
     }

--- a/src/data/repository.ts
+++ b/src/data/repository.ts
@@ -34,7 +34,9 @@ export class ParquetReader {
     );
 
     const worker = new Worker(worker_url);
-    const logger = new duckdb.ConsoleLogger();
+    // 既定は VoidLogger。ConsoleLogger は全クエリ（hover の per-point SELECT を含む）を
+    // INFO レベルで console.log するため、マウス移動時にログが氾濫し性能/可読性を損なう。
+    const logger = new duckdb.VoidLogger();
 
     this.db = new duckdb.AsyncDuckDB(logger, worker);
     await this.db.instantiate(bundle.mainModule, bundle.pthreadWorker);

--- a/src/ui/label-layer.ts
+++ b/src/ui/label-layer.ts
@@ -85,6 +85,10 @@ export class LabelLayer {
   private onLabelHover?: LabelHoverCallback;
   /** 現在ホバー中のポイント */
   private hoveredPoint: Record<string, any> | null = null;
+  /** 直近に hover した点の rowid（mousemove ごとの再クエリ抑制用。null=点上に無い） */
+  private hoveredRowid: number | null = null;
+  /** hover データ取得（findPointById）の世代カウンタ（古い非同期結果の破棄=stale guard 用） */
+  private hoverQuerySeq = 0;
   /** ホバーアウトラインのオプション */
   private hoverOutlineOptions: HoverOutlineOptions;
   /** データレイヤー参照 */
@@ -341,7 +345,7 @@ export class LabelLayer {
     const parent = this.labelCanvas.parentElement;
     if (!parent) return;
 
-    parent.addEventListener('mousemove', async (e: MouseEvent) => {
+    parent.addEventListener('mousemove', (e: MouseEvent) => {
       const rect = this.labelCanvas.getBoundingClientRect();
       const scaleX = this.labelCanvas.width / rect.width;
       const scaleY = this.labelCanvas.height / rect.height;
@@ -350,10 +354,11 @@ export class LabelLayer {
 
       const labelAtPosition = this.getLabelAtPosition(x, y);
 
-      let pointHit: Record<string, any> | null = null;
+      // 点の hit-test は spatial index だけで rowid を引く（DuckDB クエリは発行しない）。
+      let nearestRowid: number | null = null;
       if (!labelAtPosition && this.dataLayer) {
         const aspectRatio = this.labelCanvas.width / this.labelCanvas.height;
-        pointHit = await this.dataLayer.findNearestPoint(
+        nearestRowid = this.dataLayer.findNearestPointId(
           x,
           y,
           this.labelCanvas.width,
@@ -371,7 +376,7 @@ export class LabelLayer {
         this.labelCanvas.style.cursor = 'pointer';
       } else {
         this.labelCanvas.style.pointerEvents = 'none';
-        this.labelCanvas.style.cursor = pointHit ? 'pointer' : 'default';
+        this.labelCanvas.style.cursor = nearestRowid != null ? 'pointer' : 'default';
       }
 
       if (labelAtPosition !== this.hoveredLabel) {
@@ -382,15 +387,41 @@ export class LabelLayer {
         this.render();
       }
 
-      if (pointHit !== this.hoveredPoint) {
-        this.hoveredPoint = pointHit;
-
-        if (this.onPointHover) {
-          this.onPointHover(this.hoveredPoint);
-        }
-
-        this.render();
+      // hover 中の点が変わらなければ何もしない（同じ点での再クエリ・再 render を防ぐ）。
+      if (nearestRowid === this.hoveredRowid) {
+        return;
       }
+      this.hoveredRowid = nearestRowid;
+      // 進行中の hover クエリを無効化（古い結果が新しい hover を上書きしないように）。
+      const seq = ++this.hoverQuerySeq;
+
+      if (nearestRowid == null) {
+        if (this.hoveredPoint !== null) {
+          this.hoveredPoint = null;
+          if (this.onPointHover) {
+            this.onPointHover(null);
+          }
+          this.render();
+        }
+        return;
+      }
+
+      // rowid が変わったときだけ点データ本体（SELECT *）を取得する。
+      // 非同期結果は seq で検証し、古いものは破棄する（stale guard）。
+      void this.dataLayer!.findPointById(nearestRowid)
+        .then((data) => {
+          if (seq !== this.hoverQuerySeq) {
+            return;
+          }
+          this.hoveredPoint = data;
+          if (this.onPointHover) {
+            this.onPointHover(this.hoveredPoint);
+          }
+          this.render();
+        })
+        .catch(() => {
+          /* hover query failure: keep previous hovered point */
+        });
     });
 
     this.labelCanvas.addEventListener('click', (e: MouseEvent) => {
@@ -443,6 +474,8 @@ export class LabelLayer {
 
       this.hoveredLabel = null;
       this.hoveredPoint = null;
+      this.hoveredRowid = null;
+      this.hoverQuerySeq++;
 
       if (hadLabel && this.onLabelHover) {
         this.onLabelHover(null);
@@ -540,6 +573,8 @@ export class LabelLayer {
     if (data === this.hoveredPoint) {
       return;
     }
+    // 進行中の mousemove hover クエリを無効化し、その結果がこの明示設定を上書きしないようにする
+    this.hoverQuerySeq++;
     this.hoveredPoint = data;
 
     if (this.onPointHover) {

--- a/src/ui/label-layer.ts
+++ b/src/ui/label-layer.ts
@@ -573,8 +573,12 @@ export class LabelLayer {
     if (data === this.hoveredPoint) {
       return;
     }
-    // 進行中の mousemove hover クエリを無効化し、その結果がこの明示設定を上書きしないようにする
+    // 進行中の mousemove hover クエリを無効化し、その結果がこの明示設定を上書きしないようにする。
+    // hoveredRowid もリセットする: これをしないと、cursor が同じ点上にあるまま null クリア
+    // された場合、次の mousemove が `nearestRowid === this.hoveredRowid` 早期 return に当たり、
+    // 点を再取得できず onPointHover も発火しなくなる（別の点/空白へ動くまで復帰しない）。
     this.hoverQuerySeq++;
+    this.hoveredRowid = null;
     this.hoveredPoint = data;
 
     if (this.onPointHover) {


### PR DESCRIPTION
The DuckDB-WASM logger defaulted to ConsoleLogger (INFO level), which logs every query — including the per-hover SELECT * — to the console. Combined with the hover handler issuing a DuckDB query on essentially every mousemove, moving the cursor over the map flooded the console and ran a query per move.

- repository: default to VoidLogger instead of ConsoleLogger.
- data-layer: add findNearestPointId() — the spatial-index lookup only, returning the nearest rowid with no DuckDB query. findNearestPoint() now reuses it.
- label-layer mousemove: hit-test with findNearestPointId (no query) on every move; fetch point data (findPointById) only when the nearest rowid changes. The point callback/render also fire only on rowid change (previously every move, since each query returned a fresh object that never compared equal). In-flight hover queries are invalidated via a sequence counter so a stale result cannot overwrite a newer hover. The handler is no longer async.

Net effect: hovering the same point or empty space issues no query and no re-render; moving across points issues at most one query per distinct point.

Verified: tsc clean; eslint clean on changed files (only pre-existing no-explicit-any warnings).