### PR TITLE
feat: getLastUpdatePlan() introspection, gpuFilterColumns cap, shared…

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ await plot.initialize();
 * `setPan(x, y)` / `getPan()` / `pan(dx, dy)`: パン操作
 * `resetView()`: ビューリセット
 * `update(options)`: オプション更新
+* `getLastUpdatePlan()`: 直近の `update()` が DuckDB / GPU / label のどの更新経路を通ったかを取得
 * `runQuery(sql)`: カスタムSQLクエリ実行
 * `getLabels()`: ラベル全件取得
 * `destroy()`: リソース解放
@@ -191,6 +192,29 @@ await plot.update({
 * `width`: 端のランプ幅（`column` と同じ単位、`> 0`。`0` 以下でフェード無効）
 * `edges`: フェードする端（`'both'`（既定） / `'min'` / `'max'`）。`min`/`max` を省略した
   無限端は自動的にフェード無効。
+
+> `gpuFilterColumns` は最大 4 列です。5 列目以降は無視され、`CONFIG_WARNING` イベントが発火します。
+
+## 更新経路の確認
+
+`update()` の実行後、`getLastUpdatePlan()` でその更新がどの経路を通ったかを確認できます。
+UI 操作が DuckDB の再クエリを伴うのか、GPU uniform 更新だけで済んだのかをデバッグできます。
+
+```typescript
+await plot.update({ data: { gpuWhereConditions: [{ column: 'frequency', min: 500 }] } });
+console.log(plot.getLastUpdatePlan()?.paths);
+// ['gpu-filter-uniforms']
+```
+
+| 経路 | 意味 |
+|---|---|
+| `duckdb-all-points` | `sizeSql` / `colorSql` 変更により DuckDB で GPU 用 point buffer を再生成 |
+| `duckdb-visibility-flags` | `whereConditions` 変更により DuckDB で visibility bitmap を再生成 |
+| `gpu-filter-columns-buffer` | `gpuFilterColumns` 変更により GPU filter column buffer を再アップロード |
+| `gpu-filter-uniforms` | `gpuWhereConditions` / `filteredPointDisplayMode` 変更。高頻度操作向け |
+| `gpu-render-uniforms` | 背景色・透明度・サイズスケール・`visiblePointLimit` などの更新 |
+| `label-layer` | ラベル設定またはラベルデータの更新 |
+| `interaction-callbacks` | hover などの callback 更新 |
 
 ## 型定義
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,12 @@
+/**
+ * Internal/public constants that define duckscatter's current fast GPU path.
+ */
+
+/** Number of numeric columns packed into the GPU filter vec4 buffer. */
+export const MAX_GPU_FILTER_COLUMNS = 4;
+
+/** Number of f32 components stored per point in the GPU filter column buffer. */
+export const GPU_FILTER_COLUMN_COMPONENTS = 4;
+
+/** Default maximum number of points that the WebGPU LOD pass tries to keep visible. */
+export const DEFAULT_VISIBLE_POINT_LIMIT = 5_000_000;

--- a/src/data/data-layer.ts
+++ b/src/data/data-layer.ts
@@ -73,6 +73,12 @@ export class DataLayer {
   private onDataChanged?: () => void | Promise<void>;
   /** WHERE条件変更時のビジビリティ更新コールバック */
   private onVisibilityChanged?: () => void | Promise<void>;
+  /**
+   * 構築時に検出したが、まだ発火していない設定警告（gpuFilterColumns 超過など）。
+   * ScatterPlot のコンストラクタ内では consumer がまだ on('error') を登録できないため、
+   * リスナーが attach 済みになる initialize() まで発火を遅延させる。
+   */
+  private pendingConfigWarning: ScatterPlotError | null = null;
 
   /** 全ポイントデータのキャッシュ（ポイント検索用、SoA形式） */
   private pointsCache: PointsCache = {
@@ -99,35 +105,53 @@ export class DataLayer {
     this.sizeSql = options.sizeSql ?? this.sizeSql;
     this.colorSql = options.colorSql ?? this.colorSql;
     this.whereConditions = options.whereConditions ?? [];
-    this.gpuFilterColumns = this.normalizeGpuFilterColumns(options.gpuFilterColumns);
+    const capped = this.capGpuFilterColumns(options.gpuFilterColumns);
+    this.gpuFilterColumns = capped.columns;
+    // 構築時点では consumer がまだ on('error') を登録できない（コンストラクタ内）ため、
+    // 警告の発火は initialize() まで遅延する。リスナー登録後の updateOptions は即時発火。
+    this.pendingConfigWarning = capped.warning;
     this.onDataChanged = options.onDataChanged;
     this.onVisibilityChanged = options.onVisibilityChanged;
   }
 
   /**
-   * GPU filter columns は shader/buffer の fast path として vec4 に packing する。
-   * 現状は最大4列に制限し、超過分は明示的に警告して落とす。
+   * GPU filter columns は shader/buffer の fast path として vec4 に packing するため
+   * 最大 MAX_GPU_FILTER_COLUMNS 列に制限する。capping した列と、超過時に発火すべき
+   * CONFIG_WARNING を返す。副作用は持たず、警告の発火タイミングは呼び出し側に委ねる
+   * （構築時は遅延、updateOptions では即時）。
    */
-  private normalizeGpuFilterColumns(columns: string[] | undefined): string[] {
+  private capGpuFilterColumns(columns: string[] | undefined): {
+    columns: string[];
+    warning: ScatterPlotError | null;
+  } {
     const requestedColumns = columns ?? [];
     if (requestedColumns.length <= MAX_GPU_FILTER_COLUMNS) {
-      return [...requestedColumns];
+      return { columns: [...requestedColumns], warning: null };
     }
 
     const usedColumns = requestedColumns.slice(0, MAX_GPU_FILTER_COLUMNS);
     const ignoredColumns = requestedColumns.slice(MAX_GPU_FILTER_COLUMNS);
-    if (this.onError) {
-      this.onError(
-        createError(
-          'CONFIG_WARNING',
-          `gpuFilterColumns accepts at most ${MAX_GPU_FILTER_COLUMNS} columns; extra columns were ignored.`,
-          {
-            context: { maxGpuFilterColumns: MAX_GPU_FILTER_COLUMNS, usedColumns, ignoredColumns },
-          }
-        )
-      );
+    const warning = createError(
+      'CONFIG_WARNING',
+      `gpuFilterColumns accepts at most ${MAX_GPU_FILTER_COLUMNS} columns; extra columns were ignored.`,
+      {
+        context: { maxGpuFilterColumns: MAX_GPU_FILTER_COLUMNS, usedColumns, ignoredColumns },
+      }
+    );
+    return { columns: usedColumns, warning };
+  }
+
+  /**
+   * 構築時に保留した設定警告を発行する。ScatterPlot のコンストラクタ内ではリスナーを
+   * 登録できないため、リスナーが attach 済みになる initialize() の時点まで遅延させている。
+   * 一度発火したらクリアし、二重発火しない。
+   */
+  private flushPendingConfigWarning(): void {
+    const warning = this.pendingConfigWarning;
+    this.pendingConfigWarning = null;
+    if (warning && this.onError) {
+      this.onError(warning);
     }
-    return usedColumns;
   }
 
   /**
@@ -139,6 +163,8 @@ export class DataLayer {
     source: string | ArrayBuffer | File,
     onDatabaseReady?: (conn: AsyncDuckDBConnection) => Promise<void>
   ): Promise<AllPointsData> {
+    // 構築時に保留した設定警告を、リスナーが登録済みのこの時点で発行する
+    this.flushPendingConfigWarning();
     this.repository = await createParquetReader();
     if (typeof source === 'string') {
       await this.repository.loadParquetFromUrl(source);
@@ -418,11 +444,19 @@ export class DataLayer {
       }
     }
     if (options.gpuFilterColumns !== undefined) {
-      const nextColumns = this.normalizeGpuFilterColumns(options.gpuFilterColumns);
+      const capped = this.capGpuFilterColumns(options.gpuFilterColumns);
+      // この更新が gpuFilterColumns を上書きするため、構築時に保留した警告は破棄する。
+      // （未 initialize の状態でこれが呼ばれても、後続の flush で古い設定の警告が
+      //   二重発火しないようにする。現在の設定に対する警告は下で即時発火する。）
+      this.pendingConfigWarning = null;
+      // 構築後の更新では consumer が on('error') を登録済みなので即時発火してよい
+      if (capped.warning && this.onError) {
+        this.onError(capped.warning);
+      }
       const oldColumns = this.gpuFilterColumns.join(',');
-      const newColumns = nextColumns.join(',');
+      const newColumns = capped.columns.join(',');
       if (oldColumns !== newColumns) {
-        this.gpuFilterColumns = nextColumns;
+        this.gpuFilterColumns = capped.columns;
         gpuFilterColumnsChanged = true;
       }
     }

--- a/src/data/data-layer.ts
+++ b/src/data/data-layer.ts
@@ -5,6 +5,7 @@ import type { WhereCondition, ScatterPlotError } from '../types.js';
 import { createError } from '../errors.js';
 import type { AllPointsData } from '../renderer/gpu-layer.js';
 import { SpatialPointIndex } from './spatial-index.js';
+import { GPU_FILTER_COLUMN_COMPONENTS, MAX_GPU_FILTER_COLUMNS } from '../constants.js';
 
 /**
  * DataLayerの設定オプション
@@ -16,7 +17,7 @@ export interface DataLayerOptions {
   colorSql?: string;
   /** データフィルタリング用のWHERE条件 */
   whereConditions?: WhereCondition[];
-  /** GPUでフィルタリングするカラム名（最大4つ） */
+  /** GPUでフィルタリングするカラム名（最大4つ。超過分は無視される） */
   gpuFilterColumns?: string[];
   /** エラーをScatterPlotに通知するためのコールバック */
   onError?: (error: ScatterPlotError) => void;
@@ -24,6 +25,19 @@ export interface DataLayerOptions {
   onDataChanged?: () => void | Promise<void>;
   /** WHERE条件変更時にビジビリティフラグ更新が必要な場合のコールバック */
   onVisibilityChanged?: () => void | Promise<void>;
+}
+
+/**
+ * DataLayer.updateOptions が発生させた DuckDB/GPU データ境界の更新内容。
+ * 実際の GPU upload は ScatterPlot 側で行う。
+ */
+export interface DataLayerUpdateResult {
+  /** sizeSql/colorSql 変更により x/y/size/color の再 materialize が必要になった */
+  allPointsChanged: boolean;
+  /** whereConditions 変更により visibility bitmap の再生成が必要になった */
+  visibilityChanged: boolean;
+  /** gpuFilterColumns 変更により GPU filter column buffer の再アップロードが必要になった */
+  gpuFilterColumnsChanged: boolean;
 }
 
 /**
@@ -69,7 +83,7 @@ export class DataLayer {
 
   /** WhereConditionから生成されたビジビリティフラグのキャッシュ（WHERE条件なし時は空） */
   private visibilityFlags = new Uint32Array(0);
-  /** GPUフィルターカラムデータのキャッシュ（4値/ポイント） */
+  /** GPUフィルターカラムデータのキャッシュ（最大4値/ポイント） */
   private filterColumnData = new Float32Array(0);
   /** 現在のGPUフィルターレンジ（スライダーで高頻度更新） */
   private gpuFilterRanges: { columnIndex: number; min: number; max: number }[] = [];
@@ -81,13 +95,39 @@ export class DataLayer {
    * @param options 設定オプション
    */
   constructor(options: DataLayerOptions) {
+    this.onError = options.onError;
     this.sizeSql = options.sizeSql ?? this.sizeSql;
     this.colorSql = options.colorSql ?? this.colorSql;
     this.whereConditions = options.whereConditions ?? [];
-    this.gpuFilterColumns = options.gpuFilterColumns ?? [];
-    this.onError = options.onError;
+    this.gpuFilterColumns = this.normalizeGpuFilterColumns(options.gpuFilterColumns);
     this.onDataChanged = options.onDataChanged;
     this.onVisibilityChanged = options.onVisibilityChanged;
+  }
+
+  /**
+   * GPU filter columns は shader/buffer の fast path として vec4 に packing する。
+   * 現状は最大4列に制限し、超過分は明示的に警告して落とす。
+   */
+  private normalizeGpuFilterColumns(columns: string[] | undefined): string[] {
+    const requestedColumns = columns ?? [];
+    if (requestedColumns.length <= MAX_GPU_FILTER_COLUMNS) {
+      return [...requestedColumns];
+    }
+
+    const usedColumns = requestedColumns.slice(0, MAX_GPU_FILTER_COLUMNS);
+    const ignoredColumns = requestedColumns.slice(MAX_GPU_FILTER_COLUMNS);
+    if (this.onError) {
+      this.onError(
+        createError(
+          'CONFIG_WARNING',
+          `gpuFilterColumns accepts at most ${MAX_GPU_FILTER_COLUMNS} columns; extra columns were ignored.`,
+          {
+            context: { maxGpuFilterColumns: MAX_GPU_FILTER_COLUMNS, usedColumns, ignoredColumns },
+          }
+        )
+      );
+    }
+    return usedColumns;
   }
 
   /**
@@ -223,7 +263,7 @@ export class DataLayer {
       return null;
     }
 
-    const columns = this.gpuFilterColumns.slice(0, 4);
+    const columns = this.gpuFilterColumns.slice(0, MAX_GPU_FILTER_COLUMNS);
 
     try {
       const columnSelects = columns
@@ -241,11 +281,11 @@ export class DataLayer {
         return null;
       }
 
-      const filterData = new Float32Array(data.rowCount * 4);
+      const filterData = new Float32Array(data.rowCount * GPU_FILTER_COLUMN_COMPONENTS);
 
       for (let i = 0; i < data.rowCount; i++) {
-        const baseIndex = i * 4;
-        for (let j = 0; j < 4; j++) {
+        const baseIndex = i * GPU_FILTER_COLUMN_COMPONENTS;
+        for (let j = 0; j < GPU_FILTER_COLUMN_COMPONENTS; j++) {
           if (j < columns.length) {
             const colData = data.columnData.get(`__filter_col_${j}__`)!;
             filterData[baseIndex + j] = colData.get(i);
@@ -355,9 +395,7 @@ export class DataLayer {
    * @param options 更新する設定オプション
    * @returns 変更の種類を示すオブジェクト
    */
-  async updateOptions(options: Partial<DataLayerOptions>): Promise<{
-    gpuFilterColumnsChanged: boolean;
-  }> {
+  async updateOptions(options: Partial<DataLayerOptions>): Promise<DataLayerUpdateResult> {
     let needsFullReload = false;
     let needsVisibilityUpdate = false;
     let gpuFilterColumnsChanged = false;
@@ -380,10 +418,11 @@ export class DataLayer {
       }
     }
     if (options.gpuFilterColumns !== undefined) {
+      const nextColumns = this.normalizeGpuFilterColumns(options.gpuFilterColumns);
       const oldColumns = this.gpuFilterColumns.join(',');
-      const newColumns = options.gpuFilterColumns.join(',');
+      const newColumns = nextColumns.join(',');
       if (oldColumns !== newColumns) {
-        this.gpuFilterColumns = options.gpuFilterColumns;
+        this.gpuFilterColumns = nextColumns;
         gpuFilterColumnsChanged = true;
       }
     }
@@ -400,7 +439,11 @@ export class DataLayer {
       await this.onVisibilityChanged();
     }
 
-    return { gpuFilterColumnsChanged };
+    return {
+      allPointsChanged: needsFullReload,
+      visibilityChanged: needsVisibilityUpdate,
+      gpuFilterColumnsChanged,
+    };
   }
 
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,8 @@ export type {
   // GPU filter types
   GpuWhereCondition,
   FilteredPointDisplayMode,
+  ScatterPlotUpdatePath,
+  ScatterPlotUpdatePlan,
   // Error handling types
   ErrorSeverity,
   ErrorCategory,
@@ -27,6 +29,11 @@ export type {
   LabelHoverCallback,
 } from './types.js';
 
+export {
+  MAX_GPU_FILTER_COLUMNS,
+  GPU_FILTER_COLUMN_COMPONENTS,
+  DEFAULT_VISIBLE_POINT_LIMIT,
+} from './constants.js';
 export { diagnoseWebGPU } from './diagnostics.js';
 export type { WebGPUDiagnostics } from './diagnostics.js';
 

--- a/src/renderer/gpu-layer.ts
+++ b/src/renderer/gpu-layer.ts
@@ -1,6 +1,7 @@
 import { WebGPUContext } from './webgpu-context.js';
 import { scatterVertexShader, filterComputeShader, updateIndirectShader } from './shaders.js';
 import type { Color4f, FilteredPointDisplayMode } from '../types.js';
+import { DEFAULT_VISIBLE_POINT_LIMIT } from '../constants.js';
 
 /**
  * GPU用に処理されたポイントデータ
@@ -111,7 +112,7 @@ export class GpuLayer {
   /** 背景色 */
   private backgroundColor: Color4f = { r: 0, g: 0, b: 0, a: 0 };
   /** 表示可能なポイントの最大数 */
-  private visiblePointLimit: number = 5000000;
+  private visiblePointLimit: number = DEFAULT_VISIBLE_POINT_LIMIT;
   /** フィルタリング結果が有効かどうか */
   private filterResultValid: boolean = false;
 
@@ -134,7 +135,7 @@ export class GpuLayer {
     this.canvas = options.canvas;
     this.context = new WebGPUContext();
     this.backgroundColor = options.backgroundColor ?? { r: 0, g: 0, b: 0, a: 0 };
-    this.visiblePointLimit = options.visiblePointLimit ?? 5000000;
+    this.visiblePointLimit = options.visiblePointLimit ?? DEFAULT_VISIBLE_POINT_LIMIT;
     this.pointAlpha = Math.max(0, Math.min(1, options.pointAlpha ?? 1.0));
     this.pointSizeScale = Math.max(0.01, options.pointSizeScale ?? 1.0);
   }

--- a/src/scatter-plot.ts
+++ b/src/scatter-plot.ts
@@ -7,6 +7,8 @@ import type {
   LabelIdentifier,
   GpuWhereCondition,
   FilteredPointDisplayMode,
+  ScatterPlotUpdatePath,
+  ScatterPlotUpdatePlan,
 } from './types.js';
 import { DataLayer, type ParquetData } from './data/index.js';
 import { GpuLayer } from './renderer/index.js';
@@ -34,6 +36,8 @@ export class ScatterPlot extends EventEmitter<ScatterPlotEventMap> {
   private currentGpuWhereConditions: GpuWhereCondition[] = [];
   /** 直近に CONFIG_WARNING を出した「未登録 column 集合」のキー（hot path での重複 emit 抑制） */
   private lastIgnoredGpuWhereColumnsKey = '';
+  /** 直近の update() が通った更新経路（getLastUpdatePlan 用） */
+  private lastUpdatePlan: ScatterPlotUpdatePlan | null = null;
   private readonly initialFilteredPointDisplayMode?: FilteredPointDisplayMode;
 
   /** GPUフィルターカラム名→インデックスのマッピング */
@@ -308,6 +312,7 @@ export class ScatterPlot extends EventEmitter<ScatterPlotEventMap> {
    * @param options 更新する設定オプション
    */
   async update(options: Partial<ScatterPlotOptions>): Promise<void> {
+    const updatePaths = new Set<ScatterPlotUpdatePath>();
     if (options.data !== undefined) {
       const gpuWhereConditionsChanged = options.data.gpuWhereConditions !== undefined;
       if (gpuWhereConditionsChanged) {
@@ -321,7 +326,15 @@ export class ScatterPlot extends EventEmitter<ScatterPlotEventMap> {
         gpuFilterColumns: options.data.gpuFilterColumns,
       });
 
+      if (result.allPointsChanged) {
+        updatePaths.add('duckdb-all-points');
+        updatePaths.add('duckdb-visibility-flags');
+      } else if (result.visibilityChanged) {
+        updatePaths.add('duckdb-visibility-flags');
+      }
+
       if (result.gpuFilterColumnsChanged) {
+        updatePaths.add('gpu-filter-columns-buffer');
         const gpuFilterData = await this.dataLayer.loadGpuFilterColumns();
         if (gpuFilterData) {
           this.gpuLayer.uploadFilterColumns(gpuFilterData.data);
@@ -337,10 +350,12 @@ export class ScatterPlot extends EventEmitter<ScatterPlotEventMap> {
         const conditions = this.convertGpuWhereConditions(this.currentGpuWhereConditions);
         this.gpuLayer.setGpuFilterConditions(conditions);
         this.dataLayer.setGpuFilterRanges(conditions);
+        updatePaths.add('gpu-filter-uniforms');
       }
 
       if (options.data.filteredPointDisplayMode !== undefined) {
         this.gpuLayer.setFilteredPointDisplayMode(options.data.filteredPointDisplayMode);
+        updatePaths.add('gpu-filter-uniforms');
       }
     }
 
@@ -351,6 +366,7 @@ export class ScatterPlot extends EventEmitter<ScatterPlotEventMap> {
         pointAlpha: options.gpu?.pointAlpha,
         pointSizeScale: options.gpu?.pointSizeScale,
       });
+      updatePaths.add('gpu-render-uniforms');
     }
 
     if (options.labels !== undefined) {
@@ -365,6 +381,7 @@ export class ScatterPlot extends EventEmitter<ScatterPlotEventMap> {
       if (labelSource !== undefined) {
         await this.loadLabelSource(labelSource);
       }
+      updatePaths.add('label-layer');
     }
 
     if (options.interaction !== undefined) {
@@ -372,9 +389,45 @@ export class ScatterPlot extends EventEmitter<ScatterPlotEventMap> {
         onPointHover: options.interaction?.onPointHover,
         onLabelHover: options.interaction.onLabelHover,
       });
+      updatePaths.add('interaction-callbacks');
     }
 
+    this.lastUpdatePlan = this.buildUpdatePlan(updatePaths);
     this.render();
+  }
+
+  /**
+   * 直近の update() が通った DuckDB/GPU/label 更新経路を取得する。
+   * 性能調査や UI 側のデバッグ用。update() 未実行の場合は null。
+   */
+  getLastUpdatePlan(): ScatterPlotUpdatePlan | null {
+    if (!this.lastUpdatePlan) {
+      return null;
+    }
+    return { ...this.lastUpdatePlan, paths: [...this.lastUpdatePlan.paths] };
+  }
+
+  private buildUpdatePlan(pathsSet: Set<ScatterPlotUpdatePath>): ScatterPlotUpdatePlan {
+    const orderedPaths: ScatterPlotUpdatePath[] = [
+      'duckdb-all-points',
+      'duckdb-visibility-flags',
+      'gpu-filter-columns-buffer',
+      'gpu-filter-uniforms',
+      'gpu-render-uniforms',
+      'label-layer',
+      'interaction-callbacks',
+    ];
+    const paths = orderedPaths.filter((path) => pathsSet.has(path));
+    return {
+      paths,
+      duckdbAllPointsReload: pathsSet.has('duckdb-all-points'),
+      duckdbVisibilityReload: pathsSet.has('duckdb-visibility-flags'),
+      gpuFilterColumnUpload: pathsSet.has('gpu-filter-columns-buffer'),
+      gpuFilterUniformUpdate: pathsSet.has('gpu-filter-uniforms'),
+      gpuRenderUniformUpdate: pathsSet.has('gpu-render-uniforms'),
+      labelLayerUpdate: pathsSet.has('label-layer'),
+      interactionUpdate: pathsSet.has('interaction-callbacks'),
+    };
   }
 
   /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -157,7 +157,11 @@ export interface DataOptions {
   colorSql?: string;
   /** データをフィルタリングするWHERE条件（ANDのみ） */
   whereConditions?: WhereCondition[];
-  /** GPUでフィルタリングするカラム名 (最大4つ。超過分は無視され CONFIG_WARNING が発火) */
+  /**
+   * GPUでフィルタリングするカラム名 (最大4つ)。超過分は無視され CONFIG_WARNING が発火する。
+   * 初期設定での警告は `initialize()` 時に発火するため、observe するには `initialize()` より前に
+   * `on('error', ...)` を登録すること（構築後の `update()` での警告は即時発火）。
+   */
   gpuFilterColumns?: string[];
   /** GPU側で実行するフィルター条件 */
   gpuWhereConditions?: GpuWhereCondition[];

--- a/src/types.ts
+++ b/src/types.ts
@@ -111,6 +111,43 @@ export interface GpuWhereCondition {
 /** フィルターされたポイントの表示モード */
 export type FilteredPointDisplayMode = 'hidden' | 'grayed';
 
+/** update() が実際に通った処理経路 */
+export type ScatterPlotUpdatePath =
+  /** sizeSql/colorSql の変更により DuckDB で x/y/size/color を再 materialize した */
+  | 'duckdb-all-points'
+  /** whereConditions の変更、または全点再読込に伴い DuckDB で visibility bitmap を更新した */
+  | 'duckdb-visibility-flags'
+  /** gpuFilterColumns の変更により GPU filter column buffer を再アップロードした */
+  | 'gpu-filter-columns-buffer'
+  /** gpuWhereConditions/filteredPointDisplayMode の変更により GPU filter uniforms を更新した */
+  | 'gpu-filter-uniforms'
+  /** GPU 描画オプションまたは visiblePointLimit の変更により render/compute uniforms を更新した */
+  | 'gpu-render-uniforms'
+  /** ラベルレイヤーの設定またはデータを更新した */
+  | 'label-layer'
+  /** interaction callback を更新した */
+  | 'interaction-callbacks';
+
+/** update() の直近実行で使われた CPU/DuckDB/GPU 更新経路 */
+export interface ScatterPlotUpdatePlan {
+  /** 実行された処理経路。重複なし、概ねコストが高い順。 */
+  paths: ScatterPlotUpdatePath[];
+  /** DuckDB query により x/y/size/color の GPU 用 point buffer を再構築した */
+  duckdbAllPointsReload: boolean;
+  /** DuckDB query により whereConditions 用 visibility bitmap を更新した */
+  duckdbVisibilityReload: boolean;
+  /** GPU filter column buffer を再アップロードした */
+  gpuFilterColumnUpload: boolean;
+  /** GPU filter 条件または filtered point 表示モードの uniform を更新した */
+  gpuFilterUniformUpdate: boolean;
+  /** background/alpha/size scale/LOD などの GPU uniform を更新した */
+  gpuRenderUniformUpdate: boolean;
+  /** ラベルレイヤーを更新した */
+  labelLayerUpdate: boolean;
+  /** interaction callback を更新した */
+  interactionUpdate: boolean;
+}
+
 export interface DataOptions {
   /** レンダリングする表示ポイントの最大数 */
   visiblePointLimit?: number;
@@ -120,7 +157,7 @@ export interface DataOptions {
   colorSql?: string;
   /** データをフィルタリングするWHERE条件（ANDのみ） */
   whereConditions?: WhereCondition[];
-  /** GPUでフィルタリングするカラム名 (最大4つ) */
+  /** GPUでフィルタリングするカラム名 (最大4つ。超過分は無視され CONFIG_WARNING が発火) */
   gpuFilterColumns?: string[];
   /** GPU側で実行するフィルター条件 */
   gpuWhereConditions?: GpuWhereCondition[];


### PR DESCRIPTION
… constants

- constants.ts: MAX_GPU_FILTER_COLUMNS, GPU_FILTER_COLUMN_COMPONENTS, DEFAULT_VISIBLE_POINT_LIMIT (replace magic numbers in data-layer / gpu-layer).
- gpuFilterColumns: cap at MAX_GPU_FILTER_COLUMNS (4); extra columns are dropped with a CONFIG_WARNING (normalizeGpuFilterColumns), in constructor and updateOptions.
- DataLayer.updateOptions now returns DataLayerUpdateResult (allPointsChanged / visibilityChanged / gpuFilterColumnsChanged).
- ScatterPlot.getLastUpdatePlan(): expose which DuckDB / GPU / label update paths the last update() took (ScatterPlotUpdatePath / ScatterPlotUpdatePlan), for perf debugging (e.g. confirming a slider only hit gpu-filter-uniforms).
- README: document getLastUpdatePlan and the gpuFilterColumns cap.

Stacked on the gpu-row-alignment PR (uses its CONFIG_WARNING code and update() changes); rebase onto development after that PR merges.

Verified: tsc clean; eslint clean on changed files (only pre-existing no-explicit-any warnings).