### PR TITLE
fix(publish): ship dist/ in the npm package via the files whitelist

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "description": "A TypeScript library for plotting scatter charts using WebGPU",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "tsc",
     "dev": "tsc --watch",


### PR DESCRIPTION
1.6.1 was published WITHOUT dist/: package.json has `main: dist/index.js` but no `files` field and no `.npmignore`, so npm falls back to `.gitignore` (which lists `dist/`) and excludes the build output from the tarball. The CI publish job restores dist from cache, but `npm publish` still drops it, leaving consumers with `Module not found: @uoa-css-lab/duckscatter`. (1.6.0 predates dist/ being gitignored, so it still shipped dist.)

Adding `files: ["dist"]` is a whitelist that overrides .gitignore, so dist/ is always published (and src/examples/.github are trimmed from the tarball).

Verified: `npm pack --dry-run` now lists 36 dist/ entries and 0 src/ entries.