### PR TITLE
feat(selection): add highlightSelected style (dim-only selection mode)

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,6 +265,7 @@ plot.setSelectionStyle({ selectedColor: { r: 1, g: 0.2, b: 0.2, a: 1 }, unselect
 * `selectedColor`: 選択点の色（既定: 黄系の強調色）
 * `unselectedAlpha`: 選択有効時の非選択点の alpha 係数（既定 `0.25`）
 * `selectedSizeScale`: 選択点のサイズ倍率（既定 `1.35`）
+* `highlightSelected`: 選択点を `selectedColor` で塗り替えるか（既定 `true`）。`false` にすると選択点は元の色を保持し、非選択点の減衰（`unselectedAlpha`）のみ行う（クラスタ配色などを保ったまま「非選択を暗くする」dim-only 表示）
 
 > ポイント ID は Parquet の行順（rowid = ポイントバッファの index）に対応します。
 

--- a/README.md
+++ b/README.md
@@ -264,8 +264,8 @@ plot.setSelectionStyle({ selectedColor: { r: 1, g: 0.2, b: 0.2, a: 1 }, unselect
 
 * `selectedColor`: 選択点の色（既定: 黄系の強調色）
 * `unselectedAlpha`: 選択有効時の非選択点の alpha 係数（既定 `0.25`）
-* `selectedSizeScale`: 選択点のサイズ倍率（既定 `1.35`）
-* `highlightSelected`: 選択点を `selectedColor` で塗り替えるか（既定 `true`）。`false` にすると選択点は元の色を保持し、非選択点の減衰（`unselectedAlpha`）のみ行う（クラスタ配色などを保ったまま「非選択を暗くする」dim-only 表示）
+* `selectedSizeScale`: 選択点のサイズ倍率（既定 `1.35`、`highlightSelected: true` のときのみ適用）
+* `highlightSelected`: 選択点を強調するか（既定 `true`）。`true` で選択点を `selectedColor` に塗り替え `selectedSizeScale` で拡大。`false` にすると選択点は**色もサイズも元のまま**保持し、非選択点の減衰（`unselectedAlpha`）のみ行う（クラスタ配色などを保ったまま「非選択を暗くする」dim-only 表示）
 
 > ポイント ID は Parquet の行順（rowid = ポイントバッファの index）に対応します。
 

--- a/src/renderer/gpu-layer.ts
+++ b/src/renderer/gpu-layer.ts
@@ -35,6 +35,7 @@ const DEFAULT_SELECTION_STYLE: Required<SelectionStyle> = {
   selectedColor: { r: 1.0, g: 0.85, b: 0.2, a: 1.0 },
   unselectedAlpha: 0.25,
   selectedSizeScale: 1.35,
+  highlightSelected: true,
 };
 
 /**
@@ -201,6 +202,7 @@ export class GpuLayer {
       selectedColor: style?.selectedColor ?? DEFAULT_SELECTION_STYLE.selectedColor,
       unselectedAlpha: style?.unselectedAlpha ?? DEFAULT_SELECTION_STYLE.unselectedAlpha,
       selectedSizeScale: style?.selectedSizeScale ?? DEFAULT_SELECTION_STYLE.selectedSizeScale,
+      highlightSelected: style?.highlightSelected ?? DEFAULT_SELECTION_STYLE.highlightSelected,
     };
   }
 
@@ -781,7 +783,8 @@ export class GpuLayer {
     renderFloatView[39] = this.selectionStyle.selectedColor.a;
     renderFloatView[40] = this.selectionStyle.unselectedAlpha;
     renderFloatView[41] = this.selectionStyle.selectedSizeScale;
-    // [42], [43] = padding
+    renderFloatView[42] = this.selectionStyle.highlightSelected ? 1.0 : 0.0; // selectionHighlight @168
+    // [43] = padding
     this.context.device.queue.writeBuffer(this.renderUniformBuffer, 0, renderUniformData);
 
     // フィルター済みポイント用ユニフォーム（grayedMode = 1.0）

--- a/src/renderer/shaders.ts
+++ b/src/renderer/shaders.ts
@@ -211,7 +211,7 @@ struct Uniforms {
   selectionColor: vec4<f32>,        // 選択点の色
   selectionUnselectedAlpha: f32,    // 非選択点の alpha 係数（selection 有効時）
   selectionSelectedSizeScale: f32,  // 選択点のサイズ倍率
-  selectionHighlight: f32,          // 1=選択点を selectionColor で塗替, 0=元の色を保持（dim-only）
+  selectionHighlight: f32,          // 1=選択点を強調（色+サイズ）, 0=元の色・サイズを保持（dim-only）
   _selectionPad1: f32,
 }
 
@@ -306,7 +306,8 @@ fn vertexMain(
   let selected = selectionActive && isSelected(pointIdx);
 
   var effectiveSizeScale = uniforms.pointSizeScale;
-  if (uniforms.grayedMode <= 0.5 && selected) {
+  // highlightSelected=true のときだけ選択点を強調する。dim-only（=0）では色もサイズも変えない。
+  if (uniforms.grayedMode <= 0.5 && selected && uniforms.selectionHighlight > 0.5) {
     effectiveSizeScale = effectiveSizeScale * uniforms.selectionSelectedSizeScale;
   }
 

--- a/src/renderer/shaders.ts
+++ b/src/renderer/shaders.ts
@@ -211,7 +211,7 @@ struct Uniforms {
   selectionColor: vec4<f32>,        // 選択点の色
   selectionUnselectedAlpha: f32,    // 非選択点の alpha 係数（selection 有効時）
   selectionSelectedSizeScale: f32,  // 選択点のサイズ倍率
-  _selectionPad0: f32,
+  selectionHighlight: f32,          // 1=選択点を selectionColor で塗替, 0=元の色を保持（dim-only）
   _selectionPad1: f32,
 }
 
@@ -323,9 +323,9 @@ fn vertexMain(
   } else {
     var color = unpackColor(point.color);
     if (selectionActive) {
-      if (selected) {
+      if (selected && uniforms.selectionHighlight > 0.5) {
         color = uniforms.selectionColor;
-      } else {
+      } else if (!selected) {
         color = vec4<f32>(color.rgb, color.a * uniforms.selectionUnselectedAlpha);
       }
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -151,12 +151,13 @@ export interface SelectionStyle {
   selectedColor?: Color4f;
   /** selection 有効時の非選択ポイント alpha 係数（0.0-1.0、既定 0.25） */
   unselectedAlpha?: number;
-  /** 選択済みポイントのサイズ倍率（既定 1.35） */
+  /** 選択済みポイントのサイズ倍率（既定 1.35、highlightSelected が true のときのみ適用） */
   selectedSizeScale?: number;
   /**
-   * 選択点を selectedColor で塗り替えるか（既定 true）。false にすると選択点は元の色を
-   * 保持し、非選択点の減衰（unselectedAlpha）のみ行う＝クラスタ配色などを保ったまま
-   * 「非選択を暗くする」dim-only 表示になる。
+   * 選択点を強調表示するか（既定 true）。true のとき選択点を selectedColor で塗り替え、
+   * selectedSizeScale でサイズも拡大する。false にすると選択点は色もサイズも元のまま保持し、
+   * 非選択点の減衰（unselectedAlpha）のみ行う＝クラスタ配色などを保ったまま「非選択を
+   * 暗くする」dim-only 表示になる。
    */
   highlightSelected?: boolean;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -153,6 +153,12 @@ export interface SelectionStyle {
   unselectedAlpha?: number;
   /** 選択済みポイントのサイズ倍率（既定 1.35） */
   selectedSizeScale?: number;
+  /**
+   * 選択点を selectedColor で塗り替えるか（既定 true）。false にすると選択点は元の色を
+   * 保持し、非選択点の減衰（unselectedAlpha）のみ行う＝クラスタ配色などを保ったまま
+   * 「非選択を暗くする」dim-only 表示になる。
+   */
+  highlightSelected?: boolean;
 }
 
 /** update() が実際に通った処理経路 */


### PR DESCRIPTION
SelectionStyle.highlightSelected (default true) controls whether selected points are recolored to selectedColor. Set false to keep selected points' ORIGINAL color and only dim the non-selected ones (unselectedAlpha) — a "dim-only" selection that preserves an existing palette (e.g. cluster colors) by darkening everything else instead of repainting the selection one color.

No uniform-size change: the render uniform's spare pad slot (@byte 168) becomes selectionHighlight (1=recolor selected, 0=keep original); the vertex shader gates the recolor on it. Backward compatible — default true reproduces the current highlight behavior; bind groups / buffer sizes unchanged.

Verified on real WebGPU via examples/next: brushing with highlightSelected true and false both compile + run (selection count 498 in both cases), confirming the modified render shader is valid.