### PR TITLE
ci: fail the build if the npm tarball would omit dist/

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -82,6 +82,11 @@ jobs:
         with:
           path: dist
           key: dist-${{ github.sha }}
+      # Guard the workspace that is ACTUALLY published: if the dist cache restore
+      # above did not populate dist/ (cache miss / cache service issue), fail here
+      # instead of publishing a tarball without build output.
+      - name: Verify build output ships in the npm tarball
+        run: node scripts/check-package-files.mjs
       - run: npm publish --registry ${{ matrix.registry-url }} --access public
         env:
           NODE_AUTH_TOKEN: ${{ matrix.registry-url == 'https://npm.pkg.github.com' && secrets.GITHUB_TOKEN || secrets.NPMJS_TOKEN }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -38,6 +38,8 @@ jobs:
       - run: npm install --prefix examples/next
       - name: build
         run: npm run build
+      - name: Verify build output ships in the npm tarball
+        run: node scripts/check-package-files.mjs
       - name: lint
         run: npm run lint:all
       - name: test

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -53,6 +53,7 @@ module.exports = tseslint.config(
       'node_modules/**',
       'dist/**',
       'build/**',
+      'scripts/**',
       '*.js',
       '*.d.ts',
       '*.config.js',

--- a/scripts/check-package-files.mjs
+++ b/scripts/check-package-files.mjs
@@ -1,0 +1,25 @@
+// CI guard: ensure the published npm tarball includes the build output (dist/).
+//
+// Why this exists: 1.6.1 was published WITHOUT dist/. package.json points main
+// at dist/index.js but there was no "files" field and no .npmignore, so npm fell
+// back to .gitignore (which lists dist/) and dropped the compiled output from the
+// tarball — every consumer got "Module not found: @uoa-css-lab/duckscatter".
+// This check makes that failure mode fail CI instead of shipping silently.
+//
+// Run after `npm run build` (so dist/ exists on disk).
+import { execSync } from 'node:child_process';
+
+const out = JSON.parse(execSync('npm pack --dry-run --json').toString());
+const files = out[0].files.map((f) => f.path);
+const required = ['dist/index.js', 'dist/index.d.ts'];
+const missing = required.filter((r) => !files.includes(r));
+
+if (missing.length > 0) {
+  console.error(
+    `::error::npm package is missing build output: ${missing.join(', ')}. ` +
+      `Check the package.json "files" field / .npmignore (1.6.1 shipped without dist/).`
+  );
+  process.exit(1);
+}
+
+console.log(`OK: package tarball includes dist/ (${files.length} files total).`);

--- a/scripts/check-package-files.mjs
+++ b/scripts/check-package-files.mjs
@@ -1,25 +1,56 @@
-// CI guard: ensure the published npm tarball includes the build output (dist/).
+// CI guard: ensure the published npm tarball includes ALL emitted build output (dist/).
 //
-// Why this exists: 1.6.1 was published WITHOUT dist/. package.json points main
-// at dist/index.js but there was no "files" field and no .npmignore, so npm fell
-// back to .gitignore (which lists dist/) and dropped the compiled output from the
-// tarball — every consumer got "Module not found: @uoa-css-lab/duckscatter".
-// This check makes that failure mode fail CI instead of shipping silently.
+// Why this exists: 1.6.1 was published WITHOUT dist/. package.json points main at
+// dist/index.js but there was no "files" field and no .npmignore, so npm fell back
+// to .gitignore (which lists dist/) and dropped the compiled output from the tarball
+// — every consumer got "Module not found: @uoa-css-lab/duckscatter".
 //
-// Run after `npm run build` (so dist/ exists on disk).
+// Checking only the entrypoint is NOT enough: dist/index.js re-exports other emitted
+// modules (scatter-plot.js, renderer/*, data/*, ...), so a files/.npmignore change
+// that kept only dist/index.* would pass an entrypoint-only check yet still break
+// consumers resolving the entrypoint's imports. So assert EVERY file emitted under
+// dist/ on disk is present in the tarball `npm pack` would produce.
+//
+// Run after `npm run build` (ci job) or after restoring the dist cache (publish job).
 import { execSync } from 'node:child_process';
+import { readdirSync } from 'node:fs';
+import { join } from 'node:path';
+
+// Recursively list every file under a directory, as posix-style relative paths.
+function walk(dir) {
+  const out = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const p = join(dir, entry.name);
+    if (entry.isDirectory()) out.push(...walk(p));
+    else out.push(p);
+  }
+  return out;
+}
+
+let emitted;
+try {
+  emitted = walk('dist').map((p) => p.split('\\').join('/'));
+} catch {
+  console.error('::error::dist/ not found — run `npm run build`, or the dist cache restore failed.');
+  process.exit(1);
+}
+if (emitted.length === 0) {
+  console.error('::error::dist/ is empty — there is no build output to publish.');
+  process.exit(1);
+}
 
 const out = JSON.parse(execSync('npm pack --dry-run --json').toString());
-const files = out[0].files.map((f) => f.path);
-const required = ['dist/index.js', 'dist/index.d.ts'];
-const missing = required.filter((r) => !files.includes(r));
+const packed = new Set(out[0].files.map((f) => f.path.split('\\').join('/')));
 
+const missing = emitted.filter((f) => !packed.has(f));
 if (missing.length > 0) {
+  const shown = missing.slice(0, 10).join(', ');
   console.error(
-    `::error::npm package is missing build output: ${missing.join(', ')}. ` +
-      `Check the package.json "files" field / .npmignore (1.6.1 shipped without dist/).`
+    `::error::npm package would omit ${missing.length} emitted dist file(s): ` +
+      `${shown}${missing.length > 10 ? ', …' : ''}. ` +
+      `Check the package.json "files" field / .npmignore.`
   );
   process.exit(1);
 }
 
-console.log(`OK: package tarball includes dist/ (${files.length} files total).`);
+console.log(`OK: all ${emitted.length} emitted dist/ files are present in the package tarball.`);


### PR DESCRIPTION
Encodes the 1.6.1 postmortem as a permanent check. 1.6.1 was published WITHOUT dist/ — package.json points main at dist/index.js but there was no "files" field and .gitignore lists dist/, so npm dropped the build from the tarball and every consumer got "Module not found". After `npm run build`, this step runs `npm pack --dry-run --json` and fails the job unless dist/index.js and dist/index.d.ts are in the tarball. Runs on every push/PR/tag (the ci job gates the publish job), so a files-field / .npmignore regression fails fast instead of shipping a broken package.