### PR TITLE
feat(selection): GPU hover-mask to highlight a hovered cluster's nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,13 @@ GPU 常駐の選択マスク（1 bit/point）を矩形ブラシや ID 指定で�
 * `setSelectionStyle(style)`: 選択の描画スタイルを更新
 * `getSelectionCount()`: 現在の選択数を取得（`Promise<number>`）
 
+**ホバーマスク（クラスタ強調）API（selection とは独立）:**
+
+選択の dim 表示中に、ホバー中クラスタのノードだけを dim 解除して強調するための GPU 常駐マスク（1 bit/point）。selection とは別バッファで、`getSelectionCount()` / ブラシ / 選択状態を一切汚染しません。
+
+* `setHoveredPointIds(ids)`: ポイント ID（rowid）集合を hover-mask に設定（該当点の selection dim を解除し元の明度へ戻す）
+* `clearHover()`: hover-mask を全クリア（selection には影響しない）
+
 **ホバー制御API:**
 
 外部コンポーネントからプログラム的にホバー状態を制御できます。
@@ -248,6 +255,10 @@ const n = await plot.getSelectionCount();
 // 選択解除 / スタイル変更
 plot.clearSelection();
 plot.setSelectionStyle({ selectedColor: { r: 1, g: 0.2, b: 0.2, a: 1 }, unselectedAlpha: 0.15 });
+
+// hover-mask: 選択の dim 中、ホバー中クラスタのノードだけ dim を解除して強調（selection とは独立）
+plot.setHoveredPointIds([2, 5, 9]);
+plot.clearHover();
 ```
 
 **`BrushOptions`:**

--- a/src/renderer/gpu-layer.ts
+++ b/src/renderer/gpu-layer.ts
@@ -118,6 +118,8 @@ export class GpuLayer {
   private selectionFlagsBuffer: GPUBuffer | null = null;
   /** selection bit 数（render の強調/減衰ゲート用, u32×1） */
   private selectionCountBuffer: GPUBuffer | null = null;
+  /** GPU 常駐 hover bitset（1bit/point）。ホバー中クラスタのノードを selection dim から除外して強調。selection とは独立 */
+  private hoverFlagsBuffer: GPUBuffer | null = null;
   /** brush compute 用 uniform バッファ */
   private brushUniformBuffer: GPUBuffer | null = null;
   /** count compute 用 uniform バッファ */
@@ -437,6 +439,14 @@ export class GpuLayer {
     // 初期状態は全 bit 0（未選択）
     this.context.device.queue.writeBuffer(this.selectionFlagsBuffer, 0, new Uint32Array(wordCount));
 
+    // hover-mask bitset（selection と同型・別バッファ）。点集合が変わるたびに作り直してクリアする。
+    this.hoverFlagsBuffer?.destroy();
+    this.hoverFlagsBuffer = this.context.device.createBuffer({
+      size: wordCount * 4,
+      usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST,
+    });
+    this.context.device.queue.writeBuffer(this.hoverFlagsBuffer, 0, new Uint32Array(wordCount));
+
     if (!this.selectionCountBuffer) {
       this.selectionCountBuffer = this.context.device.createBuffer({
         size: 4,
@@ -490,6 +500,7 @@ export class GpuLayer {
       !this.countSelectionPipeline ||
       !this.selectionFlagsBuffer ||
       !this.selectionCountBuffer ||
+      !this.hoverFlagsBuffer ||
       !this.brushUniformBuffer ||
       !this.countUniformBuffer
     ) {
@@ -535,6 +546,7 @@ export class GpuLayer {
         { binding: 3, resource: { buffer: this.filterColumnsBuffer } },
         { binding: 4, resource: { buffer: this.selectionFlagsBuffer } },
         { binding: 5, resource: { buffer: this.selectionCountBuffer } },
+        { binding: 6, resource: { buffer: this.hoverFlagsBuffer } },
       ],
     });
 
@@ -547,6 +559,7 @@ export class GpuLayer {
         { binding: 3, resource: { buffer: this.filterColumnsBuffer } },
         { binding: 4, resource: { buffer: this.selectionFlagsBuffer } },
         { binding: 5, resource: { buffer: this.selectionCountBuffer } },
+        { binding: 6, resource: { buffer: this.hoverFlagsBuffer } },
       ],
     });
 
@@ -1295,6 +1308,36 @@ export class GpuLayer {
   }
 
   /**
+   * ポイント ID（= rowid = バッファ index）集合で hover-mask を設定する。
+   * selection とは独立した別 bitset で、ホバー中クラスタのノードを selection dim から
+   * 除外して元の明度に戻す（＝強調）。空集合（または clearHover）で解除。
+   * GPU 常駐 selection を一切触らないため getSelectionCount / brush / 投稿リストを汚染しない。
+   */
+  setHoveredPointIds(ids: Iterable<number>): void {
+    if (!this.context.device || !this.hoverFlagsBuffer) return;
+
+    const wordCount = Math.max(1, Math.ceil(this.totalPointCount / 32));
+    const bitset = new Uint32Array(wordCount);
+    for (const id of ids) {
+      if (id >= 0 && id < this.totalPointCount) {
+        const w = id >>> 5;
+        const mask = 1 << (id & 31);
+        bitset[w] |= mask;
+      }
+    }
+    this.context.device.queue.writeBuffer(this.hoverFlagsBuffer, 0, bitset);
+  }
+
+  /**
+   * hover-mask を全クリアする（selection には影響しない）。
+   */
+  clearHover(): void {
+    if (!this.context.device || !this.hoverFlagsBuffer) return;
+    const wordCount = Math.max(1, Math.ceil(this.totalPointCount / 32));
+    this.context.device.queue.writeBuffer(this.hoverFlagsBuffer, 0, new Uint32Array(wordCount));
+  }
+
+  /**
    * 現在の selection 数を取得する（GPU からの非同期読み戻し）。
    */
   async getSelectionCount(): Promise<number> {
@@ -1390,6 +1433,7 @@ export class GpuLayer {
     this.filteredRenderUniformBuffer?.destroy();
     this.selectionFlagsBuffer?.destroy();
     this.selectionCountBuffer?.destroy();
+    this.hoverFlagsBuffer?.destroy();
     this.brushUniformBuffer?.destroy();
     this.countUniformBuffer?.destroy();
     this.context.destroy();

--- a/src/renderer/shaders.ts
+++ b/src/renderer/shaders.ts
@@ -228,6 +228,7 @@ struct VertexOutput {
 @group(0) @binding(3) var<storage, read> filterColumns: array<vec4<f32>>;
 @group(0) @binding(4) var<storage, read> selectionFlags: array<u32>;
 @group(0) @binding(5) var<storage, read> selectionCount: array<u32>;
+@group(0) @binding(6) var<storage, read> hoverFlags: array<u32>;
 
 // selection が有効か（1点以上選択されているか）。空 selection では強調/減衰しない
 // （空 brush で全点が薄くなるバグを防ぐ）。
@@ -239,6 +240,14 @@ fn isSelected(pointIdx: u32) -> bool {
   let wordIndex = pointIdx / 32u;
   let bitIndex = pointIdx % 32u;
   return (selectionFlags[wordIndex] & (1u << bitIndex)) != 0u;
+}
+
+// hover-mask: ホバー中クラスタのノード（CPU で setHoveredPointIds 済み）。selection とは別 bitset。
+// hover は「selection dim を解除する」だけなので、空 bitset（全 0）なら自動的に無効＝ count ゲート不要。
+fn isHovered(pointIdx: u32) -> bool {
+  let wordIndex = pointIdx / 32u;
+  let bitIndex = pointIdx % 32u;
+  return (hoverFlags[wordIndex] & (1u << bitIndex)) != 0u;
 }
 
 // 1列ぶんの soft-edge フェード係数。width<=0 で 1.0（無効）。
@@ -304,6 +313,7 @@ fn vertexMain(
 
   let selectionActive = isSelectionActive();
   let selected = selectionActive && isSelected(pointIdx);
+  let hovered = isHovered(pointIdx);
 
   var effectiveSizeScale = uniforms.pointSizeScale;
   // highlightSelected=true のときだけ選択点を強調する。dim-only（=0）では色もサイズも変えない。
@@ -326,7 +336,8 @@ fn vertexMain(
     if (selectionActive) {
       if (selected && uniforms.selectionHighlight > 0.5) {
         color = uniforms.selectionColor;
-      } else if (!selected) {
+      } else if (!selected && !hovered) {
+        // 非選択かつ非ホバーのみ減衰。ホバー中の点は dim を解除して元の色・明度に戻す（＝強調）。
         color = vec4<f32>(color.rgb, color.a * uniforms.selectionUnselectedAlpha);
       }
     }

--- a/src/scatter-plot.ts
+++ b/src/scatter-plot.ts
@@ -691,11 +691,16 @@ export class ScatterPlot extends EventEmitter<ScatterPlotEventMap> {
   }
 
   /**
-   * すべてのホバー状態をクリアする（ポイントとラベルの両方）
+   * すべてのホバー状態をクリアする（ポイント・ラベル・GPU hover-mask）
    */
   clearAllHover(): void {
     this.labelLayer.setHoveredPoint(null);
     this.labelLayer.setHoveredLabel(null);
+    // GPU hover-mask も解除する。さもないと setHoveredPointIds で立てた bit が残り、
+    // 選択 dim 下で当該 rowid が undim のまま居残る／次に選択が有効化されたとき undim で再出現する。
+    // LabelLayer の同期 render はラベルキャンバスのみ再描画するため、点の再描画に this.render() が要る。
+    this.gpuLayer.clearHover();
+    this.render();
   }
 
   /**

--- a/src/scatter-plot.ts
+++ b/src/scatter-plot.ts
@@ -787,6 +787,25 @@ export class ScatterPlot extends EventEmitter<ScatterPlotEventMap> {
   }
 
   /**
+   * ポイント ID（rowid）集合で hover-mask を設定する（selection とは独立）。
+   * ホバー中クラスタのノードを selection dim から除外して強調する。空集合 / clearHover で解除。
+   * selection（getSelectionCount / brush 等）には一切影響しない。
+   * @param ids 強調するポイント ID（= rowid）
+   */
+  setHoveredPointIds(ids: Iterable<number>): void {
+    this.gpuLayer.setHoveredPointIds(ids);
+    this.render();
+  }
+
+  /**
+   * hover-mask を全クリアする（selection には影響しない）。
+   */
+  clearHover(): void {
+    this.gpuLayer.clearHover();
+    this.render();
+  }
+
+  /**
    * selection の描画スタイルを更新する（部分指定可）。
    * @param style selectedColor / unselectedAlpha / selectedSizeScale
    */


### PR DESCRIPTION
Adds a hover-mask: a GPU-resident bitset (1 bit/point), independent of the selection bitset, that un-dims a hovered cluster's nodes while a selection is active. Mirrors the selection machinery exactly:

- shaders.ts: binding(6) hoverFlags + isHovered(); hovered non-selected points skip the selection-dim branch (!selected && !hovered) and render at base brightness. No uniform/struct change and no count-gate (an all-zero hover bitset is inert since hover only removes dimming).
- gpu-layer.ts: hoverFlagsBuffer created/cleared in createSelectionBuffers (recreated on point-count change), bound at binding 6 in both render bind groups (layout:'auto'), destroyed in destroy(). setHoveredPointIds / clearHover write the bitset CPU-side (no GPU compute, no atomics).
- scatter-plot.ts: setHoveredPointIds(ids) / clearHover() public wrappers.
- README: document the hover-mask API.

Kept fully separate from the selection bitset: getSelectionCount, brushSelect, clearSelection and the selection count are untouched, so a consuming app's dim-only selection / count badge / post list are not polluted. clearSelection does not clear hover and vice versa.