### PR TITLE
feat(selection): setBrushActive — force selection-dim with zero selected

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ GPU 常駐の選択マスク（1 bit/point）を矩形ブラシや ID 指定で�
 * `clearSelection()`: 選択を全クリア
 * `setSelectionStyle(style)`: 選択の描画スタイルを更新
 * `getSelectionCount()`: 現在の選択数を取得（`Promise<number>`）
+* `setBrushActive(active)`: 選択点が0でも選択 dim を強制（ブラシ開始時に背景を即 dim、終了時に `false` へ戻す）
 
 **ホバーマスク（クラスタ強調）API（selection とは独立）:**
 
@@ -259,6 +260,10 @@ plot.setSelectionStyle({ selectedColor: { r: 1, g: 0.2, b: 0.2, a: 1 }, unselect
 // hover-mask: 選択の dim 中、ホバー中クラスタのノードだけ dim を解除して強調（selection とは独立）
 plot.setHoveredPointIds([2, 5, 9]);
 plot.clearHover();
+
+// ブラシ操作の開始/終了で「選択 dim」を即時に出す/消す（0 選択でも背景を dim）
+plot.setBrushActive(true);   // 右ドラッグ開始時など
+plot.setBrushActive(false);  // ジェスチャ終了時
 ```
 
 **`BrushOptions`:**

--- a/src/renderer/gpu-layer.ts
+++ b/src/renderer/gpu-layer.ts
@@ -183,6 +183,8 @@ export class GpuLayer {
   private pointSizeScale: number = 1.0;
   /** selection 描画スタイル */
   private selectionStyle: Required<SelectionStyle> = DEFAULT_SELECTION_STYLE;
+  /** 選択点が0でも選択 dim を強制するか（ブラシ操作開始時に背景を即 dim する用） */
+  private forceSelectionActive = false;
 
   /**
    * GpuLayerインスタンスを作成する
@@ -797,7 +799,7 @@ export class GpuLayer {
     renderFloatView[40] = this.selectionStyle.unselectedAlpha;
     renderFloatView[41] = this.selectionStyle.selectedSizeScale;
     renderFloatView[42] = this.selectionStyle.highlightSelected ? 1.0 : 0.0; // selectionHighlight @168
-    // [43] = padding
+    renderFloatView[43] = this.forceSelectionActive ? 1.0 : 0.0; // forceSelectionActive @172
     this.context.device.queue.writeBuffer(this.renderUniformBuffer, 0, renderUniformData);
 
     // フィルター済みポイント用ユニフォーム（grayedMode = 1.0）
@@ -1202,6 +1204,16 @@ export class GpuLayer {
    */
   setSelectionStyle(style: SelectionStyle): void {
     this.selectionStyle = this.resolveSelectionStyle({ ...this.selectionStyle, ...style });
+    this.updateUniforms();
+  }
+
+  /**
+   * 選択 dim を強制的に有効/無効にする。選択点が0でも true なら全点を dim 表示にする。
+   * ブラシ操作の開始時（まだ何も選択されていない瞬間）に背景を即 dim したいとき用。
+   * 選択が1点以上あるときは selectionCount ゲートで常に有効なのでこのフラグは無関係。
+   */
+  setBrushActive(active: boolean): void {
+    this.forceSelectionActive = active;
     this.updateUniforms();
   }
 

--- a/src/renderer/shaders.ts
+++ b/src/renderer/shaders.ts
@@ -212,7 +212,7 @@ struct Uniforms {
   selectionUnselectedAlpha: f32,    // 非選択点の alpha 係数（selection 有効時）
   selectionSelectedSizeScale: f32,  // 選択点のサイズ倍率
   selectionHighlight: f32,          // 1=選択点を強調（色+サイズ）, 0=元の色・サイズを保持（dim-only）
-  _selectionPad1: f32,
+  forceSelectionActive: f32,        // 1=選択点が0でも選択 dim を強制（ブラシ操作中など）
 }
 
 struct VertexOutput {
@@ -230,10 +230,11 @@ struct VertexOutput {
 @group(0) @binding(5) var<storage, read> selectionCount: array<u32>;
 @group(0) @binding(6) var<storage, read> hoverFlags: array<u32>;
 
-// selection が有効か（1点以上選択されているか）。空 selection では強調/減衰しない
-// （空 brush で全点が薄くなるバグを防ぐ）。
+// selection が有効か（1点以上選択されている、または forceSelectionActive で明示的に有効化）。
+// 空 selection では通常は強調/減衰しない（空 brush で全点が薄くなるバグを防ぐ）が、
+// forceSelectionActive=1 のときはブラシ操作中などとして 0 選択でも dim を有効にする。
 fn isSelectionActive() -> bool {
-  return selectionCount[0] > 0u;
+  return selectionCount[0] > 0u || uniforms.forceSelectionActive > 0.5;
 }
 
 fn isSelected(pointIdx: u32) -> bool {

--- a/src/scatter-plot.ts
+++ b/src/scatter-plot.ts
@@ -820,6 +820,17 @@ export class ScatterPlot extends EventEmitter<ScatterPlotEventMap> {
   }
 
   /**
+   * 選択 dim を強制的に有効/無効にする。選択点が0でも true なら全点を dim 表示にする。
+   * ブラシ選択の開始時（右ドラッグ開始など、まだ点が捕捉されていない瞬間）に背景を即 dim
+   * したいとき用。ジェスチャ終了時に false へ戻すこと。選択が1点以上あるときは無関係。
+   * @param active true で選択 dim を強制
+   */
+  setBrushActive(active: boolean): void {
+    this.gpuLayer.setBrushActive(active);
+    this.render();
+  }
+
+  /**
    * 現在の selection 数を取得する（GPU からの非同期読み戻し）。
    */
   async getSelectionCount(): Promise<number> {


### PR DESCRIPTION
Adds setBrushActive(active) so a consumer can show the selection-dim state the instant a brush gesture starts, before any point is captured. Without it the dim only appears once the brush rect first covers a point (the selectionCount>0 gate, which otherwise prevents an empty brush from dimming everything).

- shaders.ts: reuse the free _selectionPad1 uniform slot as forceSelectionActive (struct stays 176B, existing offsets unchanged). isSelectionActive() returns selectionCount[0] > 0u || forceSelectionActive > 0.5.
- gpu-layer.ts: forceSelectionActive field written to renderFloatView[43] (byte 172) in updateUniforms; setBrushActive(active) setter.
- scatter-plot.ts: setBrushActive(active) public wrapper.
- README: document setBrushActive.

Independent of the selection bitset/count, so getSelectionCount / brush / clearSelection are unaffected; when a real selection exists (count>0) the gate is already true and the flag is moot. Callers must pair setBrushActive(false) with gesture end / clearSelection.