### PR TITLE
feat(lod): size-ranked decimation - keep the largest nodes when zoome…

### DIFF
--- a/src/data/data-layer.ts
+++ b/src/data/data-layer.ts
@@ -222,7 +222,11 @@ export class DataLayer {
     try {
       const data = await this.repository!.query({
         toString: () =>
-          `SELECT x, y, CAST((${this.sizeSql}) AS DOUBLE) AS __size__, CAST((${this.colorSql}) AS INTEGER) AS __color__ FROM parquet_data ORDER BY rowid`,
+          `SELECT x, y, CAST((${this.sizeSql}) AS DOUBLE) AS __size__, CAST((${this.colorSql}) AS INTEGER) AS __color__, ` +
+          // サイズ基準 LOD 優先度 [0,1)（0=最大サイズ）。サイズ降順＋rowid を tiebreaker にランク付けして正規化。
+          // 均一サイズ（sizeSql=定数）なら tiebreaker の rowid 順＝ID 順になる。
+          `CAST((CAST(ROW_NUMBER() OVER (ORDER BY (${this.sizeSql}) DESC, rowid ASC) AS DOUBLE) - 1.0) / GREATEST(CAST(COUNT(*) OVER () AS DOUBLE), 1.0) AS FLOAT) AS __priority__ ` +
+          `FROM parquet_data ORDER BY rowid`,
       });
       if (!data) {
         return {
@@ -235,6 +239,7 @@ export class DataLayer {
       const yColumn = data.columnData.get('y')!;
       const sizeColumn = data.columnData.get('__size__')!;
       const colorColumn = data.columnData.get('__color__')!;
+      const priorityColumn = data.columnData.get('__priority__');
 
       const buffer = new ArrayBuffer(data.rowCount * 16);
       const floatView = new Float32Array(buffer);
@@ -258,9 +263,15 @@ export class DataLayer {
       this.pointsCache = { xArr, yArr, length: rowCount };
       this.spatialIndex.build(xArr, yArr, rowCount);
 
+      // サイズ基準 LOD 優先度（[0,1), 0=最大サイズ, rowid 順）。GPU 間引きでサイズの大きい点を優先的に残す。
+      const lodPriority = priorityColumn
+        ? new Float32Array(priorityColumn.toArray() as ArrayLike<number>)
+        : undefined;
+
       return {
         instanceData: floatView,
         totalCount: data.rowCount,
+        lodPriority,
       };
     } catch (e) {
       if (this.onError) {

--- a/src/renderer/gpu-layer.ts
+++ b/src/renderer/gpu-layer.ts
@@ -917,8 +917,11 @@ export class GpuLayer {
 
     // filteredDisplayMode: 0=hidden, 1=grayed
     computeUint32View[16] = this.filteredPointDisplayMode === 'grayed' ? 1 : 0;
-    // サイズ基準間引き: lodPriority 投入済みなら有効化し、keepFraction（維持率 [0,1]）を渡す。
-    computeUint32View[17] = this.hasLodPriority ? 1 : 0;
+    // サイズ基準間引きは「データ全体が画面に入る俯瞰（zoom<=1=visibleAreaFraction>=1）」のときだけ使う。
+    // ズームインで一部領域だけ見ているときに大域サイズ順を適用すると、小サイズの密集領域が丸ごと
+    // 消える/大サイズ領域が予算超過する（局所被覆が壊れる）ため、その場合は従来の PCG ハッシュ
+    // （ビューポートを局所的に一様サンプル）にフォールバックする。
+    computeUint32View[17] = this.hasLodPriority && this.zoom <= 1.0 ? 1 : 0;
     computeFloatView[18] = lodThreshold / 0xffffffff;
 
     this.context.device.queue.writeBuffer(this.computeUniformBuffer, 0, computeUniformData);

--- a/src/renderer/gpu-layer.ts
+++ b/src/renderer/gpu-layer.ts
@@ -47,6 +47,9 @@ export interface AllPointsData {
   instanceData: Float32Array;
   /** 全ポイント数 */
   totalCount: number;
+  /** サイズ基準 LOD 優先度 [0,1)（0=最大サイズ, rowid 順）。サイズ降順＋rowid のランクを正規化したもの。
+   *  俯瞰時の間引きを「サイズの大きい点を優先的に残す（均一サイズなら rowid 順）」にするのに使う。 */
+  lodPriority?: Float32Array;
 }
 
 /**
@@ -115,6 +118,10 @@ export class GpuLayer {
   private filterColumnsBuffer: GPUBuffer | null = null;
   /** WHERE条件による可視/非可視ビットマップバッファ */
   private visibilityFlagsBuffer: GPUBuffer | null = null;
+  /** サイズ基準 LOD 優先度バッファ（f32/point, [0,1)）。サイズの大きい点を優先的に残す間引き用 */
+  private lodPriorityBuffer: GPUBuffer | null = null;
+  /** lodPriority が投入済みでサイズ基準間引きを使えるか（未投入時は PCG ハッシュにフォールバック） */
+  private hasLodPriority = false;
   /** GPU 常駐 selection bitset（1bit/point, brush で atomic 更新） */
   private selectionFlagsBuffer: GPUBuffer | null = null;
   /** selection bit 数（render の強調/減衰ゲート用, u32×1） */
@@ -432,6 +439,14 @@ export class GpuLayer {
     initialFlags.fill(0xffffffff);
     this.context.device.queue.writeBuffer(this.visibilityFlagsBuffer, 0, initialFlags);
 
+    // サイズ基準 LOD 優先度バッファ（shader が binding 8 で常に参照するので必ず作る。データは
+    // writeLodPriority で投入し、未投入なら hasLodPriority=false で PCG フォールバックになる）。
+    this.lodPriorityBuffer = this.context.device.createBuffer({
+      size: Math.max(4, data.totalCount * 4),
+      usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST,
+    });
+    this.writeLodPriority(data);
+
     // selection 用バッファ（bitset + count + brush/count uniform）
     this.createSelectionBuffers(data.totalCount);
 
@@ -511,6 +526,7 @@ export class GpuLayer {
       !this.visibilityFlagsBuffer ||
       !this.filteredIndicesBuffer ||
       !this.filteredCounterBuffer ||
+      !this.lodPriorityBuffer ||
       !this.filteredIndirectBuffer ||
       !this.filteredRenderUniformBuffer ||
       !this.brushSelectionPipeline ||
@@ -535,6 +551,7 @@ export class GpuLayer {
         { binding: 5, resource: { buffer: this.visibilityFlagsBuffer } },
         { binding: 6, resource: { buffer: this.filteredIndicesBuffer } },
         { binding: 7, resource: { buffer: this.filteredCounterBuffer } },
+        { binding: 8, resource: { buffer: this.lodPriorityBuffer } },
       ],
     });
 
@@ -645,6 +662,13 @@ export class GpuLayer {
       initialFlags.fill(0xffffffff);
       this.context.device.queue.writeBuffer(this.visibilityFlagsBuffer, 0, initialFlags);
       this.whereFilterEnabled = false;
+
+      // サイズ基準 LOD 優先度バッファも作り直す（データは末尾の writeLodPriority で投入）。
+      this.lodPriorityBuffer?.destroy();
+      this.lodPriorityBuffer = this.context.device.createBuffer({
+        size: Math.max(4, newTotalCount * 4),
+        usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST,
+      });
     }
 
     if (countChanged) {
@@ -669,6 +693,24 @@ export class GpuLayer {
         data.instanceData.byteOffset,
         data.instanceData.byteLength
       );
+    }
+    this.writeLodPriority(data);
+  }
+
+  /** lodPriority データを GPU バッファへ投入する（無ければ hasLodPriority=false で PCG にフォールバック）。 */
+  private writeLodPriority(data: AllPointsData): void {
+    if (!this.context.device || !this.lodPriorityBuffer) return;
+    if (data.lodPriority && data.lodPriority.length >= data.totalCount && data.totalCount > 0) {
+      this.context.device.queue.writeBuffer(
+        this.lodPriorityBuffer,
+        0,
+        data.lodPriority.buffer,
+        data.lodPriority.byteOffset,
+        data.totalCount * 4
+      );
+      this.hasLodPriority = true;
+    } else {
+      this.hasLodPriority = false;
     }
   }
 
@@ -855,7 +897,8 @@ export class GpuLayer {
     computeFloatView[1] = worldMinY;
     computeFloatView[2] = worldMaxX;
     computeFloatView[3] = worldMaxY;
-    computeUint32View[4] = this.calculateLodThreshold();
+    const lodThreshold = this.calculateLodThreshold();
+    computeUint32View[4] = lodThreshold;
     computeUint32View[5] = this.totalPointCount;
 
     // activeFilterMask / filterRangeMin / filterRangeMax は上で構築済み
@@ -874,6 +917,9 @@ export class GpuLayer {
 
     // filteredDisplayMode: 0=hidden, 1=grayed
     computeUint32View[16] = this.filteredPointDisplayMode === 'grayed' ? 1 : 0;
+    // サイズ基準間引き: lodPriority 投入済みなら有効化し、keepFraction（維持率 [0,1]）を渡す。
+    computeUint32View[17] = this.hasLodPriority ? 1 : 0;
+    computeFloatView[18] = lodThreshold / 0xffffffff;
 
     this.context.device.queue.writeBuffer(this.computeUniformBuffer, 0, computeUniformData);
   }

--- a/src/renderer/shaders.ts
+++ b/src/renderer/shaders.ts
@@ -23,10 +23,10 @@ struct FilterUniforms {
   whereFilterEnabled: u32,
   filterRangeMin: vec4<f32>,
   filterRangeMax: vec4<f32>,
-  filteredDisplayMode: u32,
-  _pad1: u32,
-  _pad2: u32,
-  _pad3: u32,
+  filteredDisplayMode: u32, // computeUint32View[16]
+  useSizePriority: u32,     // computeUint32View[17]（gpu-layer updateUniforms と byte 一致が必須）
+  keepFraction: f32,        // computeFloatView[18]
+  _pad3: u32,               // [19]（FilterUniforms 合計 80 byte = COMPUTE_UNIFORM_SIZE）
 }
 
 @group(0) @binding(0) var<storage, read> allPoints: array<Point>;
@@ -37,6 +37,7 @@ struct FilterUniforms {
 @group(0) @binding(5) var<storage, read> visibilityFlags: array<u32>;
 @group(0) @binding(6) var<storage, read_write> filteredIndices: array<u32>;
 @group(0) @binding(7) var<storage, read_write> filteredCounter: atomic<u32>;
+@group(0) @binding(8) var<storage, read> lodPriority: array<f32>;
 
 var<workgroup> localCount: atomic<u32>;
 var<workgroup> localIndices: array<u32, 256>;
@@ -82,10 +83,16 @@ fn main(
   if (idx < uniforms.totalPoints) {
     let passesWhere = isVisibleByWhereFilter(idx);
 
-    // LODチェック（全ポイント共通）
+    // LODチェック（全ポイント共通）。サイズ基準 priority があればサイズの大きい点を優先的に残し、
+    // 無ければ従来の PCG ハッシュによる確率的 dropout にフォールバックする。
     var passesLOD = true;
-    let hash = pcgHash(idx);
-    passesLOD = hash <= uniforms.lodThreshold;
+    if (uniforms.useSizePriority != 0u) {
+      // lodPriority[idx] は [0,1)（0=最大サイズ）。keepFraction 以下なら残す＝大きい順に残る。
+      passesLOD = lodPriority[idx] <= uniforms.keepFraction;
+    } else {
+      let hash = pcgHash(idx);
+      passesLOD = hash <= uniforms.lodThreshold;
+    }
 
     // ビューポート境界チェック（全ポイント共通）
     var passesBounds = false;


### PR DESCRIPTION
…d out

The overview LOD previously dropped points by a PCG hash (random). Now it keeps the nodes with the largest size (the sizeSql value, e.g. retweets/likes) and drops the smallest first; with a uniform size it falls back to rowid order.

- data-layer: loadAllPoints computes a per-point priority in DuckDB (ROW_NUMBER() OVER (ORDER BY <sizeSql> DESC, rowid ASC) normalised to [0,1)) and returns it as AllPointsData.lodPriority.
- gpu-layer: a lodPriority storage buffer (binding 8, the 8th storage buffer = the WebGPU default limit) is uploaded with the data; updateUniforms passes useSizePriority + keepFraction (= the existing keep ratio).
- shader: passesLOD keeps points with priority <= keepFraction when size priority is available, else the PCG hash path (fallback when no priority data).