### PR TITLE
feat(render): clamp receded-layer (dim+gray) overdraw via offscreen c…

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,7 @@ export type {
   ScreenBrushRect,
   BrushOptions,
   SelectionStyle,
+  RecededClampOptions,
   // Update introspection types
   ScatterPlotUpdatePath,
   ScatterPlotUpdatePlan,

--- a/src/renderer/gpu-layer.ts
+++ b/src/renderer/gpu-layer.ts
@@ -5,10 +5,12 @@ import {
   updateIndirectShader,
   brushSelectionShader,
   countSelectionShader,
+  compositeShader,
 } from './shaders.js';
 import type {
   Color4f,
   FilteredPointDisplayMode,
+  RecededClampOptions,
   SelectionStyle,
   SelectionBrushMode,
   BrushBounds,
@@ -18,8 +20,10 @@ import type {
 } from '../types.js';
 import { DEFAULT_VISIBLE_POINT_LIMIT } from '../constants.js';
 
-/** render uniform buffer サイズ（selection style フィールドを含む, byte） */
-const RENDER_UNIFORM_SIZE = 176;
+/** render uniform buffer サイズ（selection style + 受動クランプフィールドを含む, byte） */
+const RENDER_UNIFORM_SIZE = 192;
+/** composite uniform buffer サイズ（maxAlpha, byte） */
+const COMPOSITE_UNIFORM_SIZE = 16;
 /** brush compute uniform buffer サイズ（byte） */
 const BRUSH_UNIFORM_SIZE = 80;
 /** count compute uniform buffer サイズ（byte） */
@@ -68,6 +72,8 @@ export interface GpuLayerOptions {
   pointSizeScale?: number;
   /** selection mask の描画スタイル */
   selectionStyle?: SelectionStyle;
+  /** 受動層（dim/gray）のオーバードロークランプ */
+  recededClamp?: RecededClampOptions;
 }
 
 // ビューポート境界のマージン（クリップ空間）
@@ -141,6 +147,31 @@ export class GpuLayer {
   private filteredIndirectBuffer: GPUBuffer | null = null;
   /** フィルター済みポイント用レンダリングユニフォームバッファ */
   private filteredRenderUniformBuffer: GPUBuffer | null = null;
+
+  // --- 受動層オーバードロークランプ（dim/gray をオフスクリーン累積→合成時に alpha 頭打ち）---
+  /** 受動層描画用 uniform（renderMode=1）。renderBindGroup と同構成で binding0 のみ差し替え */
+  private recededRenderUniformBuffer: GPUBuffer | null = null;
+  /** 受動層描画用バインドグループ（renderMode=1） */
+  private recededRenderBindGroup: GPUBindGroup | null = null;
+  /** 受動層を累積するオフスクリーンRT（canvas サイズ・format 一致） */
+  private offscreenTexture: GPUTexture | null = null;
+  /** オフスクリーンを clamp 合成するパイプライン */
+  private compositePipeline: GPURenderPipeline | null = null;
+  /** composite 用 sampler */
+  private compositeSampler: GPUSampler | null = null;
+  /** composite 用 uniform（maxAlpha） */
+  private compositeUniformBuffer: GPUBuffer | null = null;
+  /** composite 用バインドグループ（offscreen 再生成時に作り直す） */
+  private compositeBindGroup: GPUBindGroup | null = null;
+  /** オフスクリーンの現サイズ（canvas と不一致なら再生成） */
+  private offscreenWidth = 0;
+  private offscreenHeight = 0;
+  /** 受動クランプ有効か（無効なら従来の単一パス＝後方互換） */
+  private recededClampEnabled = false;
+  /** 受動層の累積 alpha 上限 */
+  private recededMaxAlpha = 0.5;
+  /** 受動とみなす予約色 [r,g,b]（0-255）。null=色ベース判定なし（dim のみ受動） */
+  private recededColor: [number, number, number] | null = null;
 
   /** GPUフィルター条件（range + optional soft-edge fade） */
   private gpuFilterConditions: {
@@ -219,6 +250,7 @@ export class GpuLayer {
     this.pointAlpha = Math.max(0, Math.min(1, options.pointAlpha ?? 1.0));
     this.pointSizeScale = Math.max(0.01, options.pointSizeScale ?? 1.0);
     this.selectionStyle = this.resolveSelectionStyle(options.selectionStyle);
+    this.applyRecededClamp(options.recededClamp);
   }
 
   /** 部分指定の SelectionStyle を既定値で埋める */
@@ -321,6 +353,36 @@ export class GpuLayer {
       },
     });
 
+    // 受動層クランプ用 composite パイプライン（オフスクリーンをサンプルし alpha を頭打ちにして合成）。
+    // composite の出力は premultiplied なので blend は premultiplied-over（src=one）。
+    const compositeShaderModule = this.context.device.createShaderModule({
+      code: compositeShader,
+    });
+    this.compositePipeline = this.context.device.createRenderPipeline({
+      layout: 'auto',
+      vertex: { module: compositeShaderModule, entryPoint: 'vertexMain' },
+      fragment: {
+        module: compositeShaderModule,
+        entryPoint: 'fragmentMain',
+        targets: [
+          {
+            format: this.context.format,
+            blend: {
+              color: { srcFactor: 'one', dstFactor: 'one-minus-src-alpha', operation: 'add' },
+              alpha: { srcFactor: 'one', dstFactor: 'one-minus-src-alpha', operation: 'add' },
+            },
+          },
+        ],
+      },
+      primitive: { topology: 'triangle-list' },
+    });
+    this.compositeSampler = this.context.device.createSampler({
+      magFilter: 'nearest',
+      minFilter: 'nearest',
+      addressModeU: 'clamp-to-edge',
+      addressModeV: 'clamp-to-edge',
+    });
+
     const brushShaderModule = this.context.device.createShaderModule({
       code: brushSelectionShader,
     });
@@ -419,6 +481,16 @@ export class GpuLayer {
 
     this.filteredRenderUniformBuffer = this.context.device.createBuffer({
       size: RENDER_UNIFORM_SIZE,
+      usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
+    });
+
+    // 受動層描画用 uniform（renderMode=1）と composite 用 uniform（maxAlpha）。
+    this.recededRenderUniformBuffer = this.context.device.createBuffer({
+      size: RENDER_UNIFORM_SIZE,
+      usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
+    });
+    this.compositeUniformBuffer = this.context.device.createBuffer({
+      size: COMPOSITE_UNIFORM_SIZE,
       usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
     });
 
@@ -529,6 +601,7 @@ export class GpuLayer {
       !this.lodPriorityBuffer ||
       !this.filteredIndirectBuffer ||
       !this.filteredRenderUniformBuffer ||
+      !this.recededRenderUniformBuffer ||
       !this.brushSelectionPipeline ||
       !this.countSelectionPipeline ||
       !this.selectionFlagsBuffer ||
@@ -575,6 +648,20 @@ export class GpuLayer {
       layout: this.renderPipeline.getBindGroupLayout(0),
       entries: [
         { binding: 0, resource: { buffer: this.renderUniformBuffer } },
+        { binding: 1, resource: { buffer: this.allPointsBuffer } },
+        { binding: 2, resource: { buffer: this.visibleIndicesBuffer } },
+        { binding: 3, resource: { buffer: this.filterColumnsBuffer } },
+        { binding: 4, resource: { buffer: this.selectionFlagsBuffer } },
+        { binding: 5, resource: { buffer: this.selectionCountBuffer } },
+        { binding: 6, resource: { buffer: this.hoverFlagsBuffer } },
+      ],
+    });
+
+    // 受動層描画用（renderMode=1）。renderBindGroup と同じ可視インデックスで uniform だけ差し替え。
+    this.recededRenderBindGroup = this.context.device.createBindGroup({
+      layout: this.renderPipeline.getBindGroupLayout(0),
+      entries: [
+        { binding: 0, resource: { buffer: this.recededRenderUniformBuffer } },
         { binding: 1, resource: { buffer: this.allPointsBuffer } },
         { binding: 2, resource: { buffer: this.visibleIndicesBuffer } },
         { binding: 3, resource: { buffer: this.filterColumnsBuffer } },
@@ -857,12 +944,35 @@ export class GpuLayer {
     renderFloatView[41] = this.selectionStyle.selectedSizeScale;
     renderFloatView[42] = this.selectionStyle.highlightSelected ? 1.0 : 0.0; // selectionHighlight @168
     renderFloatView[43] = this.forceSelectionActive ? 1.0 : 0.0; // forceSelectionActive @172
+    // 受動クランプ: main は renderMode=2(焦点のみ) / 無効時は 0(全描画)。受動予約色（gray）も渡す。
+    renderUint32View[44] = this.recededClampEnabled ? 2 : 0; // renderMode @176
+    const rc = this.recededColor;
+    renderFloatView[45] = rc ? rc[0] / 255.0 : -1.0; // recededR @180（負=色ベース判定なし）
+    renderFloatView[46] = rc ? rc[1] / 255.0 : -1.0; // recededG @184
+    renderFloatView[47] = rc ? rc[2] / 255.0 : -1.0; // recededB @188
     this.context.device.queue.writeBuffer(this.renderUniformBuffer, 0, renderUniformData);
 
-    // フィルター済みポイント用ユニフォーム（grayedMode = 1.0）
+    // 受動層描画用ユニフォーム（renderMode = 1 = 受動のみ）。main と同内容で renderMode だけ差し替え。
+    if (this.recededRenderUniformBuffer) {
+      const recededData = renderUniformData.slice(0);
+      new Uint32Array(recededData)[44] = 1; // renderMode = 受動のみ
+      this.context.device.queue.writeBuffer(this.recededRenderUniformBuffer, 0, recededData);
+    }
+
+    // composite uniform（受動層の累積 alpha 上限）
+    if (this.compositeUniformBuffer) {
+      this.context.device.queue.writeBuffer(
+        this.compositeUniformBuffer,
+        0,
+        new Float32Array([this.recededMaxAlpha])
+      );
+    }
+
+    // フィルター済みポイント用ユニフォーム（grayedMode = 1.0、renderMode = 0 = discard しない）
     if (this.filteredRenderUniformBuffer) {
       const filteredRenderUniformData = renderUniformData.slice(0);
       new Float32Array(filteredRenderUniformData)[21] = 1.0; // grayedMode = 1.0
+      new Uint32Array(filteredRenderUniformData)[44] = 0; // renderMode = 全（discard なし）
       // grayed パスはフィルタ範囲 [min,max] の外側の点を描画するため、フェードを
       // 適用すると computeFadeAlpha が 0 になり点が消えてしまう（gray 表示にならない）。
       // fadeEdgeFlags を 0 にしてフェードを無効化し、常に gray で表示する。
@@ -930,6 +1040,45 @@ export class GpuLayer {
   /**
    * 散布図をレンダリングする
    */
+  /**
+   * 受動層オフスクリーンRT と composite bind group を canvas サイズに合わせて用意する。
+   * サイズ変化時は作り直す。準備できれば true（受動クランプの3パスを実行可能）。
+   */
+  private ensureOffscreen(): boolean {
+    const device = this.context.device;
+    if (
+      !device ||
+      !this.compositePipeline ||
+      !this.compositeSampler ||
+      !this.compositeUniformBuffer ||
+      !this.recededRenderBindGroup
+    ) {
+      return false;
+    }
+    const w = this.canvas.width;
+    const h = this.canvas.height;
+    if (w === 0 || h === 0) return false;
+    if (!this.offscreenTexture || this.offscreenWidth !== w || this.offscreenHeight !== h) {
+      this.offscreenTexture?.destroy();
+      this.offscreenTexture = device.createTexture({
+        size: { width: w, height: h },
+        format: this.context.format,
+        usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TEXTURE_BINDING,
+      });
+      this.offscreenWidth = w;
+      this.offscreenHeight = h;
+      this.compositeBindGroup = device.createBindGroup({
+        layout: this.compositePipeline.getBindGroupLayout(0),
+        entries: [
+          { binding: 0, resource: { buffer: this.compositeUniformBuffer } },
+          { binding: 1, resource: this.compositeSampler },
+          { binding: 2, resource: this.offscreenTexture.createView() },
+        ],
+      });
+    }
+    return !!this.compositeBindGroup;
+  }
+
   render(): void {
     if (
       !this.context.device ||
@@ -1003,7 +1152,66 @@ export class GpuLayer {
       this.filterResultValid = true;
     }
 
-    {
+    if (this.recededClampEnabled && this.ensureOffscreen()) {
+      // ── 受動層クランプ: 受動(dim/gray)をオフスクリーンに通常累積 → 合成時に alpha 頭打ち → 焦点を上に ──
+      // 1) 受動層（renderMode=1）をオフスクリーン（透明クリア）に累積描画。
+      {
+        const offPass = commandEncoder.beginRenderPass({
+          colorAttachments: [
+            {
+              view: this.offscreenTexture!.createView(),
+              clearValue: { r: 0, g: 0, b: 0, a: 0 },
+              loadOp: 'clear',
+              storeOp: 'store',
+            },
+          ],
+        });
+        offPass.setPipeline(this.renderPipeline);
+        offPass.setVertexBuffer(0, this.quadVertexBuffer);
+        offPass.setIndexBuffer(this.indexBuffer!, 'uint16');
+        offPass.setBindGroup(0, this.recededRenderBindGroup!);
+        offPass.drawIndexedIndirect(this.indirectBuffer, 0);
+        offPass.end();
+      }
+      // 2) main: 背景クリア → 時間フィルタ層(背面・対象外) → 受動層を clamp 合成 → 焦点層(renderMode=2)。
+      {
+        const textureView = this.context.context.getCurrentTexture().createView();
+        const mainPass = commandEncoder.beginRenderPass({
+          colorAttachments: [
+            {
+              view: textureView,
+              clearValue: {
+                r: this.backgroundColor.r,
+                g: this.backgroundColor.g,
+                b: this.backgroundColor.b,
+                a: this.backgroundColor.a,
+              },
+              loadOp: 'clear',
+              storeOp: 'store',
+            },
+          ],
+        });
+        if (isGrayed) {
+          mainPass.setPipeline(this.renderPipeline);
+          mainPass.setVertexBuffer(0, this.quadVertexBuffer);
+          mainPass.setIndexBuffer(this.indexBuffer!, 'uint16');
+          mainPass.setBindGroup(0, this.filteredRenderBindGroup);
+          mainPass.drawIndexedIndirect(this.filteredIndirectBuffer, 0);
+        }
+        // 受動層オフスクリーンを clamp 合成（フルスクリーン三角形）。
+        mainPass.setPipeline(this.compositePipeline!);
+        mainPass.setBindGroup(0, this.compositeBindGroup!);
+        mainPass.draw(3);
+        // 焦点層（renderMode=2 で受動を discard）。
+        mainPass.setPipeline(this.renderPipeline);
+        mainPass.setVertexBuffer(0, this.quadVertexBuffer);
+        mainPass.setIndexBuffer(this.indexBuffer!, 'uint16');
+        mainPass.setBindGroup(0, this.renderBindGroup);
+        mainPass.drawIndexedIndirect(this.indirectBuffer, 0);
+        mainPass.end();
+      }
+    } else {
+      // ── 従来の単一パス（受動クランプ無効＝後方互換）──
       const textureView = this.context.context.getCurrentTexture().createView();
       const renderPass = commandEncoder.beginRenderPass({
         colorAttachments: [
@@ -1162,6 +1370,10 @@ export class GpuLayer {
       });
       needsUniformUpdate = true;
     }
+    if (options.recededClamp !== undefined) {
+      this.applyRecededClamp(options.recededClamp);
+      needsUniformUpdate = true;
+    }
 
     if (needsUniformUpdate) {
       this.updateUniforms();
@@ -1313,6 +1525,28 @@ export class GpuLayer {
    */
   setSelectionStyle(style: SelectionStyle): void {
     this.selectionStyle = this.resolveSelectionStyle({ ...this.selectionStyle, ...style });
+    this.updateUniforms();
+  }
+
+  /** recededClamp オプションをフィールドへ反映（updateUniforms は呼ばない＝呼び出し側で制御）。 */
+  private applyRecededClamp(opts?: RecededClampOptions): void {
+    if (!opts) return;
+    this.recededClampEnabled = opts.enabled;
+    if (opts.maxAlpha !== undefined) {
+      this.recededMaxAlpha = Math.max(0, Math.min(1, opts.maxAlpha));
+    }
+    if (opts.recededColor !== undefined) {
+      this.recededColor = opts.recededColor;
+    }
+  }
+
+  /**
+   * 受動層（dim/gray）のオーバードロークランプを設定する。enabled=true で受動点をオフスクリーンに
+   * 累積し、合成時に累積 alpha を maxAlpha で頭打ちにする（密集しても不透明化しない）。
+   * recededColor を指定すると、その色の点（例: 投稿フィルタ非該当の gray）も受動扱いにする。
+   */
+  setRecededClamp(opts: RecededClampOptions): void {
+    this.applyRecededClamp(opts);
     this.updateUniforms();
   }
 
@@ -1607,6 +1841,9 @@ export class GpuLayer {
     this.filteredCounterBuffer?.destroy();
     this.filteredIndirectBuffer?.destroy();
     this.filteredRenderUniformBuffer?.destroy();
+    this.recededRenderUniformBuffer?.destroy();
+    this.compositeUniformBuffer?.destroy();
+    this.offscreenTexture?.destroy();
     this.selectionFlagsBuffer?.destroy();
     this.selectionCountBuffer?.destroy();
     this.hoverFlagsBuffer?.destroy();

--- a/src/renderer/gpu-layer.ts
+++ b/src/renderer/gpu-layer.ts
@@ -1169,11 +1169,18 @@ export class GpuLayer {
         offPass.setPipeline(this.renderPipeline);
         offPass.setVertexBuffer(0, this.quadVertexBuffer);
         offPass.setIndexBuffer(this.indexBuffer!, 'uint16');
+        // 時間フィルタの灰色層（grayedMode=1）も受動なので、ここで累積してクランプ対象にする
+        // （main へ直接描くと composite を迂回し、密集で不透明化してしまう）。背面なので先に描く。
+        if (isGrayed) {
+          offPass.setBindGroup(0, this.filteredRenderBindGroup);
+          offPass.drawIndexedIndirect(this.filteredIndirectBuffer, 0);
+        }
+        // 通常 visible のうち受動（renderMode=1 で焦点を discard）を累積。
         offPass.setBindGroup(0, this.recededRenderBindGroup!);
         offPass.drawIndexedIndirect(this.indirectBuffer, 0);
         offPass.end();
       }
-      // 2) main: 背景クリア → 時間フィルタ層(背面・対象外) → 受動層を clamp 合成 → 焦点層(renderMode=2)。
+      // 2) main: 背景クリア → 受動層(時間フィルタ灰色＋dim/gray を累積済み)を clamp 合成 → 焦点層(renderMode=2)。
       {
         const textureView = this.context.context.getCurrentTexture().createView();
         const mainPass = commandEncoder.beginRenderPass({
@@ -1191,14 +1198,7 @@ export class GpuLayer {
             },
           ],
         });
-        if (isGrayed) {
-          mainPass.setPipeline(this.renderPipeline);
-          mainPass.setVertexBuffer(0, this.quadVertexBuffer);
-          mainPass.setIndexBuffer(this.indexBuffer!, 'uint16');
-          mainPass.setBindGroup(0, this.filteredRenderBindGroup);
-          mainPass.drawIndexedIndirect(this.filteredIndirectBuffer, 0);
-        }
-        // 受動層オフスクリーンを clamp 合成（フルスクリーン三角形）。
+        // 受動層オフスクリーン（時間フィルタ灰色＋dim/gray を累積済み）を clamp 合成（フルスクリーン三角形）。
         mainPass.setPipeline(this.compositePipeline!);
         mainPass.setBindGroup(0, this.compositeBindGroup!);
         mainPass.draw(3);

--- a/src/renderer/shaders.ts
+++ b/src/renderer/shaders.ts
@@ -220,6 +220,11 @@ struct Uniforms {
   selectionSelectedSizeScale: f32,  // 選択点のサイズ倍率
   selectionHighlight: f32,          // 1=選択点を強調（色+サイズ）, 0=元の色・サイズを保持（dim-only）
   forceSelectionActive: f32,        // 1=選択点が0でも選択 dim を強制（ブラシ操作中など）
+  // --- 受動層オーバードロークランプ ---
+  renderMode: u32,                  // 0=全描画(従来), 1=受動(dim/gray)のみ, 2=焦点のみ
+  recededR: f32,                    // 受動とみなす予約色 RGB（負で無効＝色ベース判定なし）
+  recededG: f32,
+  recededB: f32,
 }
 
 struct VertexOutput {
@@ -227,6 +232,7 @@ struct VertexOutput {
   @location(0) color: vec4<f32>,
   @location(1) pointCoord: vec2<f32>,
   @location(2) fadeAlpha: f32,
+  @location(3) isReceded: f32,       // 1=受動層（dim/gray）, 0=焦点層
 }
 
 @group(0) @binding(0) var<uniform> uniforms: Uniforms;
@@ -339,8 +345,18 @@ fn vertexMain(
 
   if (uniforms.grayedMode > 0.5) {
     output.color = vec4<f32>(0.6, 0.6, 0.6, 0.35);
+    output.isReceded = 1.0; // 時間フィルタ層（grayed）も受動扱い
   } else {
     var color = unpackColor(point.color);
+    // 受動判定は選択減衰前の素の色で行う：非選択 dim、または予約色（フィルタ非該当のグレー）一致。
+    let isDim = selectionActive && !selected && !hovered;
+    // 予約色は厳密値（u8/255 は f32 で正確に往復）なので、しきい値は丸め誤差吸収用に狭く取り、
+    // クラスタ配色がグレー近傍に当たる誤検出面を最小化する（±1/255 程度）。
+    let isGrayColor = uniforms.recededR >= 0.0 &&
+      abs(color.r - uniforms.recededR) < 0.004 &&
+      abs(color.g - uniforms.recededG) < 0.004 &&
+      abs(color.b - uniforms.recededB) < 0.004;
+    output.isReceded = select(0.0, 1.0, isDim || isGrayColor);
     if (selectionActive) {
       if (selected && uniforms.selectionHighlight > 0.5) {
         color = uniforms.selectionColor;
@@ -360,6 +376,14 @@ fn vertexMain(
 
 @fragment
 fn fragmentMain(input: VertexOutput) -> @location(0) vec4<f32> {
+  // 受動/焦点パスの振り分け（1=受動のみ, 2=焦点のみ, 0=全描画）。
+  if (uniforms.renderMode == 1u && input.isReceded < 0.5) {
+    discard;
+  }
+  if (uniforms.renderMode == 2u && input.isReceded > 0.5) {
+    discard;
+  }
+
   let d = input.pointCoord - vec2<f32>(0.5);
   let distSq = dot(d, d);
 
@@ -370,6 +394,56 @@ fn fragmentMain(input: VertexOutput) -> @location(0) vec4<f32> {
   let alpha = smoothstep(0.25, 0.23, distSq);
 
   return vec4<f32>(input.color.rgb, input.color.a * alpha * uniforms.pointAlpha * input.fadeAlpha);
+}
+`;
+
+/**
+ * 受動層オフスクリーン（premultiplied 累積）を main へ合成するシェーダー。
+ * 累積 alpha を maxAlpha で頭打ちにして「密集してもオーバードローで不透明化しない」を実現する。
+ * フルスクリーン三角形でオフスクリーンをサンプルし、premultiplied を保ったまま rgb を比例スケール。
+ */
+export const compositeShader = `
+struct CompositeUniforms {
+  maxAlpha: f32,
+}
+
+@group(0) @binding(0) var<uniform> cu: CompositeUniforms;
+@group(0) @binding(1) var samp: sampler;
+@group(0) @binding(2) var tex: texture_2d<f32>;
+
+struct CompositeOut {
+  @builtin(position) position: vec4<f32>,
+  @location(0) uv: vec2<f32>,
+}
+
+@vertex
+fn vertexMain(@builtin(vertex_index) vi: u32) -> CompositeOut {
+  // フルスクリーン三角形（3頂点でクリップ空間を覆う）
+  var positions = array<vec2<f32>, 3>(
+    vec2<f32>(-1.0, -1.0),
+    vec2<f32>( 3.0, -1.0),
+    vec2<f32>(-1.0,  3.0)
+  );
+  let p = positions[vi];
+  var out: CompositeOut;
+  out.position = vec4<f32>(p, 0.0, 1.0);
+  // clip → テクスチャ uv（y 反転）。offscreen と canvas は同じ clip→fb 写像なので画面位置が一致する。
+  out.uv = vec2<f32>((p.x + 1.0) * 0.5, (1.0 - p.y) * 0.5);
+  return out;
+}
+
+@fragment
+fn fragmentMain(input: CompositeOut) -> @location(0) vec4<f32> {
+  // offscreen は premultiplied 累積（rgb は既に ×a）。累積 a を maxAlpha で頭打ちにし、
+  // premultiplied を保つよう rgb を同じ比率でスケールする。
+  let c = textureSample(tex, samp, input.uv);
+  let a = c.a;
+  if (a <= 0.0001) {
+    discard;
+  }
+  let aClamped = min(cu.maxAlpha, a);
+  let scale = aClamped / a;
+  return vec4<f32>(c.rgb * scale, aClamped);
 }
 `;
 

--- a/src/scatter-plot.ts
+++ b/src/scatter-plot.ts
@@ -72,6 +72,7 @@ export class ScatterPlot extends EventEmitter<ScatterPlotEventMap> {
       pointAlpha: options.gpu?.pointAlpha,
       pointSizeScale: options.gpu?.pointSizeScale,
       selectionStyle: options.gpu?.selection,
+      recededClamp: options.gpu?.recededClamp,
     });
 
     this.labelLayer = new LabelLayer({
@@ -376,6 +377,7 @@ export class ScatterPlot extends EventEmitter<ScatterPlotEventMap> {
         pointAlpha: options.gpu?.pointAlpha,
         pointSizeScale: options.gpu?.pointSizeScale,
         selectionStyle: options.gpu?.selection,
+        recededClamp: options.gpu?.recededClamp,
       });
       updatePaths.add('gpu-render-uniforms');
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -229,6 +229,18 @@ export interface GpuOptions {
   pointSizeScale?: number;
   /** selection mask の描画スタイル */
   selection?: SelectionStyle;
+  /** 受動層（dim/gray）のオーバードロークランプ */
+  recededClamp?: RecededClampOptions;
+}
+
+/** 受動層（dim/gray）オーバードロークランプの設定（密集してもオーバードローで不透明化させない） */
+export interface RecededClampOptions {
+  /** クランプ有効か */
+  enabled: boolean;
+  /** 受動層の累積 alpha 上限（0-1, 既定 0.5） */
+  maxAlpha?: number;
+  /** 受動とみなす予約色 [r,g,b]（0-255）。投稿フィルタ非該当の gray 等。省略で dim のみ受動 */
+  recededColor?: [number, number, number] | null;
 }
 
 export interface LabelOptions {


### PR DESCRIPTION
…omposite

Dense regions of dimmed (unselected) or reserved-gray (filtered-out) points accumulated to opaque under standard over-blending (1-(1-a)^N), defeating the visual dim/gray. Now receded points render to an offscreen, accumulate, and composite with the accumulated alpha clamped to maxAlpha (density caps instead of going opaque); focus points render normally on top.

- New gpu config: gpu.recededClamp { enabled, maxAlpha, recededColor }.
- Render uniform gains renderMode (0=all/1=receded/2=focus) + recededColor; vertex flags isReceded (dim OR reserved-color OR grayed); fragment discards by pass. Offscreen accumulates premultiplied; composite clamps with premult- over blend. Backward compatible (disabled = original single pass).